### PR TITLE
Make pacote really cache, by giving it a directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .nyc_output
 coverage
+legacy-cache

--- a/src/.env-example
+++ b/src/.env-example
@@ -2,3 +2,6 @@ NODE_ENV=development
 DEV_LATENCY_ERROR_MS=10000
 POSTGRES_URL=postgres://postgres@127.0.0.1:5432
 PORT=3000
+PGUSER=postgres
+PGDATABASE=entropic_dev
+CACHE_DIR=../legacy-cache

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^7.0.0",
     "find-my-way": "~2.0.1",
     "micro": "~9.3.3",
+    "mkdirp": "~0.5.1",
     "node-fetch": "^2.4.1",
     "ormnomnom": "^5.2.2",
     "pacote": "~9.5.0",

--- a/src/registry/lib/cache.js
+++ b/src/registry/lib/cache.js
@@ -4,7 +4,18 @@
 // The filesystem edition is a thin wrapper around pacote.
 // The S3 edition is a little more... complex. Also unimplemented.
 
+const fs = require('fs');
+const mkdirp = require('mkdirp');
 const pacote = require('pacote');
+const path = require('path');
+
+const CACHE_DIR = path.resolve(process.env.CACHE_DIR || '../../legacy-cache');
+const OPTS = {
+  cache: CACHE_DIR
+};
+if (!fs.existsSync(CACHE_DIR)) {
+  mkdirp(CACHE_DIR);
+}
 
 module.exports = {
   manifest,
@@ -13,13 +24,13 @@ module.exports = {
 };
 
 async function manifest(spec) {
-  return await pacote.manifest(spec);
+  return await pacote.manifest(spec, OPTS);
 }
 
 async function packument(spec) {
-  return await pacote.packument(spec);
+  return await pacote.packument(spec, OPTS);
 }
 
 async function tarball(spec) {
-  return pacote.tarball.stream(spec);
+  return pacote.tarball.stream(spec, OPTS);
 }


### PR DESCRIPTION
The directory is specified an env var. If the process can't create it, it just crashes. This is correct for the moment.