### PR TITLE
fix: create authentication rows when logging in with oauth

### DIFF
--- a/src/registry/handlers/www.js
+++ b/src/registry/handlers/www.js
@@ -110,6 +110,7 @@ async function oauthCallback(context, { provider: providerName }) {
 
   const remoteAuth = {
     token,
+    id: remote.id,
     provider: provider.name,
     username: remote.username || '',
     email: remote.email || ''
@@ -195,10 +196,7 @@ async function signupAction(context) {
     return signup(context);
   }
 
-  const { access: accessSealed } = cookie.parse(
-    context.request.headers.cookie || ''
-  );
-  const user = await User.signup(username, email, accessSealed);
+  const user = await User.signup(username, email, context.session.get('remoteAuth'));
 
   context.session.delete('remoteAuth');
   context.session.set('user', user.name);

--- a/src/registry/models/user.js
+++ b/src/registry/models/user.js
@@ -14,26 +14,18 @@ module.exports = class User {
     this.active = active;
   }
 
-  static async signup(name, email, accessEncrypted) {
+  static async signup(name, email, remoteAuth) {
     const user = await User.objects.create({
       name,
       email
     });
 
-    if (accessEncrypted) {
-      const { remote, provider } = JSON.parse(
-        await iron.unseal(
-          accessEncrypted,
-          process.env.OAUTH_PASSWORD,
-          iron.defaults
-        )
-      );
-
+    if (remoteAuth) {
       await Authentication.objects.create({
         user,
-        remote_identity: remote.id,
-        provider,
-        access_token_enc: accessEncrypted,
+        remote_identity: remoteAuth.id,
+        provider: remoteAuth.provider,
+        access_token_enc: await iron.seal(remoteAuth.token, process.env.OAUTH_PASSWORD, iron.defaults),
         metadata: {}
       });
     }


### PR DESCRIPTION
Nix a remnant of the old "create random cookies" approach that slipped through silently.