### PR TITLE
issue #29 add a code of conduct for contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,150 @@
+# Code of Conduct
+
+## When Something Happens
+
+If you see a Code of Conduct violation, follow these steps:
+
+1. Let the person know that what they did is not appropriate and ask them to stop and/or edit their message(s) or commits.
+2. That person should immediately stop the behavior and correct the issue.
+3. If this doesn’t happen, or if you're uncomfortable speaking up, [contact the maintainers](#contacting-maintainers).
+4. As soon as available, a maintainer will look into the issue, and take [further action (see below)](#further-enforcement), starting with a warning, then temporary block, then long-term repo or organization ban.
+
+When reporting, please include any relevant details, links, screenshots, context, or other information that may be used to better understand and resolve the situation.
+
+**The maintainer team will prioritize the well-being and comfort of the recipients of the violation over the comfort of the violator.** See [some examples below](#enforcement-examples).
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers of this project pledge to making participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, technical preferences, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+  * Using welcoming and inclusive language.
+  * Being respectful of differing viewpoints and experiences.
+  * Gracefully accepting constructive feedback.
+  * Focusing on what is best for the community.
+  * Showing empathy and kindness towards other community members.
+  * Encouraging and raising up your peers in the project so you can all bask in hacks and glory.
+
+Examples of unacceptable behavior by participants include:
+
+  * The use of sexualized language or imagery and unwelcome sexual attention or advances, including when simulated online. The only exception to sexual topics is channels/spaces specifically for topics of sexual identity.
+  * Casual mention of slavery or indentured servitude and/or false comparisons of one's occupation or situation to slavery. Please consider using or asking about alternate terminology when referring to such metaphors in technology.
+  * Making light of/making mocking comments about trigger warnings and content warnings.
+  * Trolling, insulting/derogatory comments, and personal or political attacks.
+  * Public or private harassment, deliberate intimidation, or threats.
+  * Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of "outing" of any aspect of someone's identity without their consent.
+  * Publishing private screenshots or quotes of interactions in the context of this project without all quoted users' *explicit* consent.
+  * Publishing of private communication that doesn't have to do with reporting harrassment.
+  * Any of the above even when [presented as "ironic" or "joking"](https://en.wikipedia.org/wiki/Hipster_racism).
+  * Any attempt to present "reverse-ism" versions of the above as violations. Examples of reverse-isms are "reverse racism", "reverse sexism", "heterophobia", and "cisphobia".
+  * Unsolicited explanations under the assumption that someone doesn't already know it. Ask before you teach! Don't assume what people's knowledge gaps are.
+  * [Feigning or exaggerating surprise](https://www.recurse.com/manual#no-feigned-surprise) when someone admits to not knowing something.
+  * "[Well-actuallies](https://www.recurse.com/manual#no-well-actuallys)"
+  * Other conduct which could reasonably be considered inappropriate in a professional or community setting.
+
+## Scope
+
+This Code of Conduct applies both within spaces involving this project and in other spaces involving community members. This includes the repository, its Pull Requests and Issue tracker, its Twitter community, private email communications in the context of the project, and any events where members of the project are participating, as well as adjacent communities and venues affecting the project's members.
+
+Depending on the violation, the maintainers may decide that violations of this code of conduct that have happened outside of the scope of the community may deem an individual unwelcome, and take appropriate action to maintain the comfort and safety of its members.
+
+### Other Community Standards
+
+As a project on GitHub, this project is additionally covered by the [GitHub Community Guidelines](https://help.github.com/articles/github-community-guidelines/).
+
+Additionally, as a project hosted on npm, is is covered by [npm, Inc's Code of Conduct](https://www.npmjs.com/policies/conduct).
+
+Enforcement of those guidelines after violations overlapping with the above are the responsibility of the entities, and enforcement may happen in any or all of the services/communities.
+
+## Maintainer Enforcement Process
+
+Once the maintainers get involved, they will follow a documented series of steps and do their best to preserve the well-being of project members. This section covers actual concrete steps.
+
+### Contacting Maintainers
+
+You may get in touch with the maintainer team through any of the following methods:
+
+  * Through email:
+    * [ceejceej@gmail.com](mailto:ceejceej@gmail.com) (C J Silverio)
+    * [chris@neversaw.us](mailto:chris@neversaw.us) (Chris Dickinson)
+
+### Further Enforcement
+
+If you've already followed the [initial enforcement steps](#enforcement), these are the steps maintainers will take for further enforcement, as needed:
+
+  1. Repeat the request to stop.
+  2. If the person doubles down, they will have offending messages removed or edited by a maintainers given an official warning. The PR or Issue may be locked.
+  3. If the behavior continues or is repeated later, the person will be blocked from participating for 24 hours.
+  4. If the behavior continues or is repeated after the temporary block, a long-term (6-12mo) ban will be used.
+
+On top of this, maintainers may remove any offending messages, images, contributions, etc, as they deem necessary.
+
+Maintainers reserve full rights to skip any of these steps, at their discretion, if the violation is considered to be a serious and/or immediate threat to the health and well-being of members of the community. These include any threats, serious physical or verbal attacks, and other such behavior that would be completely unacceptable in any social setting that puts our members at risk.
+
+Members expelled from events or venues with any sort of paid attendance will not be refunded.
+
+### Who Watches the Watchers?
+
+Maintainers and other leaders who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership. These may include anything from removal from the maintainer team to a permanent ban from the community.
+
+Additionally, as a project hosted on both GitHub and npm, [their own Codes of Conducts may be applied against maintainers of this project](#other-community-standards), externally of this project's procedures.
+
+### Enforcement Examples
+
+#### The Best Case
+
+The vast majority of situations work out like this. This interaction is common, and generally positive.
+
+> Alex: "Yeah I used X and it was really crazy!"
+
+> Patt (not a maintainer): "Hey, could you not use that word? What about 'ridiculous' instead?"
+
+> Alex: "oh sorry, sure." -> edits old comment to say "it was really confusing!"
+
+#### The Maintainer Case
+
+Sometimes, though, you need to get maintainers involved. Maintainers will do their best to resolve conflicts, but people who were harmed by something **will take priority**.
+
+> Patt: "Honestly, sometimes I just really hate using $library and anyone who uses it probably sucks at their job."
+
+> Alex: "Whoa there, could you dial it back a bit? There's a CoC thing about attacking folks' tech use like that."
+
+> Patt: "I'm not attacking anyone, what's your problem?"
+
+> Alex: "@maintainers hey uh. Can someone look at this issue? Patt is getting a bit aggro. I tried to nudge them about it, but nope."
+
+> KeeperOfCommitBits: (on issue) "Hey Patt, maintainer here. Could you tone it down? This sort of attack is really not okay in this space."
+
+> Patt: "Leave me alone I haven't said anything bad wtf is wrong with you."
+
+> KeeperOfCommitBits: (deletes user's comment), "@patt I mean it. Please refer to the CoC over at (URL to this CoC) if you have questions, but you can consider this an actual warning. I'd appreciate it if you reworded your messages in this thread, since they made folks there uncomfortable. Let's try and be kind, yeah?"
+
+> Patt: "@keeperofbits Okay sorry. I'm just frustrated and I'm kinda burnt out and I guess I got carried away. I'll DM Alex a note apologizing and edit my messages. Sorry for the trouble."
+
+> KeeperOfCommitBits: "@patt Thanks for that. I hear you on the stress. Burnout sucks :/.  Have a good one!"
+
+#### The Nope Case
+
+> PepeTheFrog🐸: "Hi, I am a literal actual nazi and I think white supremacists are quite fashionable."
+
+> Patt: "NOOOOPE. OH NOPE NOPE."
+
+> Alex: "JFC NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
+
+> KeeperOfCommitBits: "👀 Nope. NOPE NOPE NOPE. 🔥"
+
+> PepeTheFrog🐸 has been banned from all organization or user repositories belonging to KeeperOfCommitBits.
+
+## Attribution
+
+This Code of Conduct was generated using [WeAllJS Code of Conduct Generator](https://npm.im/weallbehave), which is based on the [WeAllJS Code of
+Conduct](https://wealljs.org/code-of-conduct), which is itself based on
+[Contributor Covenant](http://contributor-covenant.org), version 1.4, available
+at
+[http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4),
+and the LGBTQ in Technology Slack [Code of
+Conduct](http://lgbtq.technology/coc.html).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,257 @@
+# Contributing
+
+## How do I... <a name="toc"></a>
+
+* [Use This Guide](#introduction)?
+* Ask or Say Something? 🤔🐛😱
+  * [Request Support](#request-support)
+  * [Report an Error or Bug](#report-an-error-or-bug)
+  * [Request a Feature](#request-a-feature)
+* Make Something? 🤓👩🏽‍💻📜🍳
+  * [Project Setup](#project-setup)
+  * [Contribute Documentation](#contribute-documentation)
+  * [Contribute Code](#contribute-code)
+* Manage Something ✅🙆🏼💃👔
+  * [Provide Support on Issues](#provide-support-on-issues)
+  * [Label Issues](#label-issues)
+  * [Clean Up Issues and PRs](#clean-up-issues-and-prs)
+  * [Review Pull Requests](#review-pull-requests)
+  * [Merge Pull Requests](#merge-pull-requests)
+  * [Tag a Release](#tag-a-release)
+  * [Join the Project Team](#join-the-project-team)
+* Add a Guide Like This One [To My Project](#attribution)? 🤖😻👻
+
+## Introduction
+
+Thank you so much for your interest in contributing!. All types of contributions are encouraged and valued. See the [table of contents](#toc) for different ways to help and details about how this project handles them!📝
+
+Please make sure to read the relevant section before making your contribution! It will make it a lot easier for us maintainers to make the most of it and smooth out the experience for all involved. 💚
+
+The [Project Team](#join-the-project-team) looks forward to your contributions. 🙌🏾✨
+
+## Request Support
+
+If you have a question about this project, how to use it, or just need clarification about something:
+
+* Open an Issue at https://github.com/entropic-dev/entropic/issues
+* Provide as much context as you can about what you're running into.
+* Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant. If not, please be ready to provide that information if maintainers ask for it.
+
+Once it's filed:
+
+* The project team will [label the issue](#label-issues).
+* Someone will try to have a response soon.
+* If you or the maintainers don't respond to an issue for 30 days, the [issue will be closed](#clean-up-issues-and-prs). If you want to come back to it, reply (once, please), and we'll reopen the existing issue. Please avoid filing new issues as extensions of one you already made.
+
+## Report an Error or Bug
+
+If you run into an error or bug with the project:
+
+* Open an Issue at https://github.com/entropic-dev/entropic/issues
+* Include *reproduction steps* that someone else can follow to recreate the bug or error on their own.
+* Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant. If not, please be ready to provide that information if maintainers ask for it.
+
+Once it's filed:
+
+* The project team will [label the issue](#label-issues).
+* A team member will try to reproduce the issue with your provided steps. If there are no repro steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+* If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#contribute-code).
+* If you or the maintainers don't respond to an issue for 30 days, the [issue will be closed](#clean-up-issues-and-prs). If you want to come back to it, reply (once, please), and we'll reopen the existing issue. Please avoid filing new issues as extensions of one you already made.
+* `critical` issues may be left open, depending on perceived immediacy and severity, even past the 30 day deadline.
+
+## Request a Feature
+
+If the project doesn't do something you need or want it to do:
+
+* Open an Issue at https://github.com/entropic-dev/entropic/issues
+* Provide as much context as you can about what you're running into.
+* Please try and be clear about why existing features and alternatives would not work for you.
+
+Once it's filed:
+
+* The project team will [label the issue](#label-issues).
+* The project team will evaluate the feature request, possibly asking you more questions to understand its purpose and any relevant requirements. If the issue is closed, the team will convey their reasoning and suggest an alternative path forward.
+* If the feature request is accepted, it will be marked for implementation with `feature-accepted`, which can then be done by either by a core team member or by anyone in the community who wants to [contribute code](#contribute-code).
+
+Note: The team is unlikely to be able to accept every single feature request that is filed. Please understand if they need to say no.
+
+## Project Setup
+
+So you wanna contribute some code! That's great! This project uses GitHub Pull Requests to manage contributions, so [read up on how to fork a GitHub project and file a PR](https://guides.github.com/activities/forking) if you've never done it before.
+
+If this seems like a lot or you aren't able to do all this setup, you might also be able to [edit the files directly](https://help.github.com/articles/editing-files-in-another-user-s-repository/) without having to do any of this setup. Yes, [even code](#contribute-code).
+
+If you want to go the usual route and run the project locally, though:
+
+* [Install Node.js](https://nodejs.org/en/download/)
+* [Fork the project](https://guides.github.com/activities/forking/#fork)
+
+Then in your terminal:
+* `cd path/to/your/clone`
+* `npm install`
+* `npm test`
+
+And you should be ready to go!
+
+## Contribute Documentation
+
+Documentation is a super important, critical part of this project. Docs are how we keep track of what we're doing, how, and why. It's how we stay on the same page about our policies. And it's how we tell others everything they need in order to be able to use this project -- or contribute to it. So thank you in advance.
+
+Documentation contributions of any size are welcome! Feel free to file a PR even if you're just rewording a sentence to be more clear, or fixing a spelling mistake!
+
+To contribute documentation:
+
+* [Set up the project](#project-setup).
+* Edit or add any relevant documentation.
+* Make sure your changes are formatted correctly and consistently with the rest of the documentation.
+* Re-read what you wrote, and run a spellchecker on it to make sure you didn't miss anything.
+* In your commit message(s), begin the first line with `docs: `. For example: `docs: Adding a doc contrib section to CONTRIBUTING.md`.
+* Write clear, concise commit message(s) using [conventional-changelog format](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md). Documentation commits should use `docs(<component>): <message>`.
+* Go to https://github.com/entropic-dev/entropic/pulls and open a new pull request with your changes.
+* If your PR is connected to an open issue, add a line in your PR's description that says `Fixes: #123`, where `#123` is the number of the issue you're fixing.
+
+Once you've filed the PR:
+
+* One or more maintainers will use GitHub's review feature to review your PR.
+* If the maintainer asks for any changes, edit your changes, push, and ask for another review.
+* If the maintainer decides to pass on your PR, they will thank you for the contribution and explain why they won't be accepting the changes. That's ok! We still really appreciate you taking the time to do it, and we don't take that lightly. 💚
+* If your PR gets accepted, it will be marked as such, and merged into the `latest` branch soon after. Your contribution will be distributed to the masses next time the maintainers [tag a release](#tag-a-release)
+
+## Contribute Code
+
+We like code commits a lot! They're super handy, and they keep the project going and doing the work it needs to do to be useful to others.
+
+Code contributions of just about any size are acceptable!
+
+The main difference between code contributions and documentation contributions is that contributing code requires inclusion of relevant tests for the code being added or changed. Contributions without accompanying tests will be held off until a test is added, unless the maintainers consider the specific tests to be either impossible, or way too much of a burden for such a contribution.
+
+To contribute code:
+
+* [Set up the project](#project-setup).
+* Make any necessary changes to the source code.
+* Include any [additional documentation](#contribute-documentation) the changes might need.
+* Write tests that verify that your contribution works as expected.
+* Write clear, concise commit message(s) using [conventional-changelog format](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).
+* Dependency updates, additions, or removals must be in individual commits, and the message must use the format: `<prefix>(deps): PKG@VERSION`, where `<prefix>` is any of the usual `conventional-changelog` prefixes, at your discretion.
+* Go to https://github.com/entropic-dev/entropic/pulls and open a new pull request with your changes.
+* If your PR is connected to an open issue, add a line in your PR's description that says `Fixes: #123`, where `#123` is the number of the issue you're fixing.
+
+Once you've filed the PR:
+
+* Barring special circumstances, maintainers will not review PRs until all checks pass (Travis, AppVeyor, etc).
+* One or more maintainers will use GitHub's review feature to review your PR.
+* If the maintainer asks for any changes, edit your changes, push, and ask for another review. Additional tags (such as `needs-tests`) will be added depending on the review.
+* If the maintainer decides to pass on your PR, they will thank you for the contribution and explain why they won't be accepting the changes. That's ok! We still really appreciate you taking the time to do it, and we don't take that lightly. 💚
+* If your PR gets accepted, it will be marked as such, and merged into the `latest` branch soon after. Your contribution will be distributed to the masses next time the maintainers [tag a release](#tag-a-release)
+
+## Provide Support on Issues
+
+[Needs Collaborator](#join-the-project-team): none
+
+Helping out other users with their questions is a really awesome way of contributing to any community. It's not uncommon for most of the issues on an open source projects being support-related questions by users trying to understand something they ran into, or find their way around a known bug.
+
+Sometimes, the `support` label will be added to things that turn out to actually be other things, like bugs or feature requests. In that case, suss out the details with the person who filed the original issue, add a comment explaining what the bug is, and change the label from `support` to `bug` or `feature`. If you can't do this yourself, @mention a maintainer so they can do it.
+
+In order to help other folks out with their questions:
+
+* Go to the issue tracker and [filter open issues by the `support` label](https://github.com/entropic-dev/entropic/issues?q=is%3Aopen+is%3Aissue+label%3Asupport).
+* Read through the list until you find something that you're familiar enough with to give an answer to.
+* Respond to the issue with whatever details are needed to clarify the question, or get more details about what's going on.
+* Once the discussion wraps up and things are clarified, either close the issue, or ask the original issue filer (or a maintainer) to close it for you.
+
+Some notes on picking up support issues:
+
+* Avoid responding to issues you don't know you can answer accurately.
+* As much as possible, try to refer to past issues with accepted answers. Link to them from your replies with the `#123` format.
+* Be kind and patient with users -- often, folks who have run into confusing things might be upset or impatient. This is ok. Try to understand where they're coming from, and if you're too uncomfortable with the tone, feel free to stay away or withdraw from the issue. (note: if the user is outright hostile or is violating the CoC, [refer to the Code of Conduct](CODE_OF_CONDUCT.md) to resolve the conflict).
+
+## Label Issues
+
+[Needs Collaborator](#join-the-project-team): Issue Tracker
+
+One of the most important tasks in handling issues is labeling them usefully and accurately. All other tasks involving issues ultimately rely on the issue being classified in such a way that relevant parties looking to do their own tasks can find them quickly and easily.
+
+In order to label issues, [open up the list of unlabeled issues](https://github.com/entropic-dev/entropic/issues?q=is%3Aopen+is%3Aissue+no%3Alabel) and, **from newest to oldest**, read through each one and apply issue labels according to the table below. If you're unsure about what label to apply, skip the issue and try the next one: don't feel obligated to label each and every issue yourself!
+
+Label | Apply When | Notes
+--- | --- | ---
+`bug` | Cases where the code (or documentation) is behaving in a way it wasn't intended to. | If something is happening that surprises the *user* but does not go against the way the code is designed, it should use the `enhancement` label.
+`critical` | Added to `bug` issues if the problem described makes the code completely unusable in a common situation. |
+`documentation` | Added to issues or pull requests that affect any of the documentation for the project. | Can be combined with other labels, such as `bug` or `enhancement`.
+`duplicate` | Added to issues or PRs that refer to the exact same issue as another one that's been previously labeled. | Duplicate issues should be marked and closed right away, with a message referencing the issue it's a duplicate of (with `#123`)
+`enhancement` | Added to [feature requests](#request-a-feature), PRs, or documentation issues that are purely additive: the code or docs currently work as expected, but a change is being requested or suggested. |
+`help wanted` | Applied by [Committers](#join-the-project-team) to issues and PRs that they would like to get outside help for. Generally, this means it's lower priority for the maintainer team to itself implement, but that the community is encouraged to pick up if they so desire | Never applied on first-pass labeling.
+`in-progress` | Applied by [Committers](#join-the-project-team) to PRs that are pending some work before they're ready for review. | The original PR submitter should @mention the team member that applied the label once the PR is complete.
+`performance` | This issue or PR is directly related to improving performance. |
+`refactor` | Added to issues or PRs that deal with cleaning up or modifying the project for the betterment of it. |
+`starter` | Applied by [Committers](#join-the-project-team) to issues that they consider good introductions to the project for people who have not contributed before. These are not necessarily "easy", but rather focused around how much context is necessary in order to understand what needs to be done for this project in particular. | Existing project members are expected to stay away from these unless they increase in priority.
+`support` | This issue is either asking a question about how to use the project, clarifying the reason for unexpected behavior, or possibly reporting a `bug` but does not have enough detail yet to determine whether it would count as such. | The label should be switched to `bug` if reliable reproduction steps are provided. Issues primarily with unintended configurations of a user's environment are not considered bugs, even if they cause crashes.
+`tests` | This issue or PR either requests or adds primarily tests to the project. | If a PR is pending tests, that will be handled through the [PR review process](#review-pull-requests)
+`wontfix` | Labelers may apply this label to issues that clearly have nothing at all to do with the project or are otherwise entirely outside of its scope/sphere of influence. [Committers](#join-the-project-team) may apply this label and close an issue or PR if they decide to pass on an otherwise relevant issue. | The issue or PR should be closed as soon as the label is applied, and a clear explanation provided of why the label was used. Contributors are free to contest the labeling, but the decision ultimately falls on committers as to whether to accept something or not.
+
+## Clean Up Issues and PRs
+
+[Needs Collaborator](#join-the-project-team): Issue Tracker
+
+Issues and PRs can go stale after a while. Maybe they're abandoned. Maybe the team will just plain not have time to address them any time soon.
+
+In these cases, they should be closed until they're brought up again or the interaction starts over.
+
+To clean up issues and PRs:
+
+* Search the issue tracker for issues or PRs, and add the term `updated:<=YYYY-MM-DD`, where the date is 30 days before today.
+* Go through each issue *from oldest to newest*, and close them if **all of the following are true**:
+  * not opened by a maintainer
+  * not marked as `critical`
+  * not marked as `starter` or `help wanted` (these might stick around for a while, in general, as they're intended to be available)
+  * no explicit messages in the comments asking for it to be left open
+  * does not belong to a milestone
+* Leave a message when closing saying "Cleaning up stale issue. Please reopen or ping us if and when you're ready to resume this. See https://github.com/entropic-dev/entropic/blob/latest/CONTRIBUTING.md#clean-up-issues-and-prs for more details."
+
+## Review Pull Requests
+
+[Needs Collaborator](#join-the-project-team): Issue Tracker
+
+While anyone can comment on a PR, add feedback, etc, PRs are only *approved* by team members with Issue Tracker or higher permissions.
+
+PR reviews use [GitHub's own review feature](https://help.github.com/articles/about-pull-request-reviews/), which manages comments, approval, and review iteration.
+
+Some notes:
+
+* You may ask for minor changes ("nitpicks"), but consider whether they are really blockers to merging: try to err on the side of "approve, with comments".
+* *ALL PULL REQUESTS* should be covered by a test: either by a previously-failing test, an existing test that covers the entire functionality of the submitted code, or new tests to verify any new/changed behavior. All tests must also pass and follow established conventions. Test coverage should not drop, unless the specific case is considered reasonable by maintainers.
+* Please make sure you're familiar with the code or documentation being updated, unless it's a minor change (spellchecking, minor formatting, etc). You may @mention another project member who you think is better suited for the review, but still provide a non-approving review of your own.
+* Be extra kind: people who submit code/doc contributions are putting themselves in a pretty vulnerable position, and have put time and care into what they've done (even if that's not obvious to you!) -- always respond with respect, be understanding, but don't feel like you need to sacrifice your standards for their sake, either. Just don't be a jerk about it?
+
+## Merge Pull Requests
+
+[Needs Collaborator](#join-the-project-team): Committer
+
+TBD - need to hash out a bit more of this process.
+
+## Tag A Release
+
+[Needs Collaborator](#join-the-project-team): Committer
+
+TBD - need to hash out a bit more of this process. The most important bit here is probably that all tests must pass, and tags must use [semver](https://semver.org).
+
+## Join the Project Team
+
+### Ways to Join
+
+There are many ways to contribute! Most of them don't require any official status unless otherwise noted. That said, there's a couple of positions that grant special repository abilities, and this section describes how they're granted and what they do.
+
+All of the below positions are granted based on the project team's needs, as well as their consensus opinion about whether they would like to work with the person and think that they would fit well into that position. The process is relatively informal, and it's likely that people who express interest in participating can just be granted the permissions they'd like.
+
+You can spot a collaborator on the repo by looking for the `[Collaborator]` or `[Owner]` tags next to their names.
+
+Permission | Description
+--- | ---
+Issue Tracker | Granted to contributors who express a strong interest in spending time on the project's issue tracker. These tasks are mainly [labeling issues](#label-issues), [cleaning up old ones](#clean-up-issues-and-prs), and [reviewing pull requests](#review-pull-requests), as well as all the usual things non-team-member contributors can do. Issue handlers should not merge pull requests, tag releases, or directly commit code themselves: that should still be done through the usual pull request process. Becoming an Issue Handler means the project team trusts you to understand enough of the team's process and context to implement it on the issue tracker.
+Committer | Granted to contributors who want to handle the actual pull request merges, tagging new versions, etc. Committers should have a good level of familiarity with the codebase, and enough context to understand the implications of various changes, as well as a good sense of the will and expectations of the project team.
+Admin/Owner | Granted to people ultimately responsible for the project, its community, etc.
+
+## Attribution
+
+This guide was generated using the WeAllJS `CONTRIBUTING.md` generator. [Make your own](https://npm.im/weallcontribute)!
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "entropic",
+  "description": "A new package registry with a new CLI, designed to be easy to stand up inside your network.",
+  "version": "1.0.0",
+  "author": "C J Silverio <ceejceej@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/entropic-dev/entropic/issues"
+  },
+  "contributors": [
+    "C J Silverio <ceejceej@gmail.com>",
+    "Chris Dickinson <chris@neversaw.us> (http://neversaw.us/)"
+  ],
+  "directories": {
+    "doc": "docs"
+  },
+  "homepage": "https://github.com/entropic-dev/entropic#readme",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/entropic-dev/entropic.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
a code of conduct, thanks to weallbehave
a contributing guide, thanks to weallcontribute

Both are still 100% boilerplate.

https://github.com/entropic-dev/entropic/issues/29