### PR TITLE
fix: defaults missing from dotenv config

### DIFF
--- a/registry/server.js
+++ b/registry/server.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-require('dotenv').config();
+require('dotenv').config({
+  PORT:3000,
+  EXTERNAL_HOST:"http://localhost:3000"
+});
 
 const isDev = require('are-we-dev');
 const bistre = require('bistre');


### PR DESCRIPTION
when PORT is missing the server listens on a random port and prints that
it's listening on undefined.
"2019-05-30T12:15:44.135Z  info runner: listening on port: undefined"

when running tests, or starting the server on a clean checkout, db
migrations crash related to an undefined env var EXTERNAL_HOST.