### PR TITLE
fix: dotenv doesnt work that way. fixes defaults.

### DIFF
--- a/registry/lib/config.js
+++ b/registry/lib/config.js
@@ -1,0 +1,7 @@
+require('dotenv').config()
+process.env = Object.assign({
+  PORT:3000,
+  EXTERNAL_HOST:"http://localhost:3000"
+},process.env);
+
+module.exports = process.env;

--- a/registry/server.js
+++ b/registry/server.js
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-require('dotenv').config({
-  PORT:3000,
-  EXTERNAL_HOST:"http://localhost:3000"
-});
+require('./lib/config');
 
 const isDev = require('are-we-dev');
 const bistre = require('bistre');
@@ -26,5 +23,7 @@ if (isDev()) {
 const handler = makeRequestHandler(router, middleware);
 const server = micro((req, res) => handler(req, res));
 
-server.listen(process.env.PORT, '0.0.0.0');
-logger.info(`listening on port: ${process.env.PORT}`);
+server.listen(process.env.PORT, '0.0.0.0',()=>{
+  logger.info(`listening on port: ${server.address().port}`);
+});
+

--- a/registry/test/11-config.js
+++ b/registry/test/11-config.js
@@ -1,0 +1,26 @@
+/* eslint-env node, mocha */
+'use strict';
+
+const cachedEnv = process.env;
+const assert = require("assert")
+
+describe(__filename,()=>{
+    it("configure has defaults",()=>{
+        delete process.env.PORT;
+        require('../lib/config')
+
+        assert.strictEqual(process.env.PORT,3000)
+        assert.strictEqual(process.env.EXTERNAL_HOST,'http://localhost:3000')
+    })
+
+    it("configure uses ENV value over default value.",()=>{
+        process.env.PORT = 1337;
+        require('../lib/config')
+
+        assert.strictEqual(process.env.PORT,1337)
+    })
+
+    after(()=>{
+        process.env = cachedEnv;
+    })
+})


### PR DESCRIPTION
the thing i did doesnt work! =)
moved dotenv call to it's own file.
added tests that the env keys with defaults are set if missing and that user values override defaults