### PR TITLE
[feat] Set up system for locale-specific help

### DIFF
--- a/cli/lib/commands/help-download-en_us.txt
+++ b/cli/lib/commands/help-download-en_us.txt
@@ -1,0 +1,3 @@
+Help for: ds download
+
+    Fetch & insert into cache the content blobs for the named package-version.

--- a/cli/lib/commands/help-invite-en_us.txt
+++ b/cli/lib/commands/help-invite-en_us.txt
@@ -1,0 +1,5 @@
+Help for: ds invite [name] --to [pkg/namespace]
+
+    Invite a namespace to join the maintainers list for a given package or 
+    namespace.
+    

--- a/cli/lib/commands/help-login-en_us.txt
+++ b/cli/lib/commands/help-login-en_us.txt
@@ -1,0 +1,7 @@
+Help for: ds login
+    
+    Run this command to login to the preferred registry specified in your
+    ~/.entropicrc file. (Default: https://registry.entropic.dev). Running the 
+    command will open a browser window to authorize the registy access to
+    your Github account for authorization. Return to the terminal to complete
+    the login.

--- a/cli/lib/commands/help-publish-en_us.txt
+++ b/cli/lib/commands/help-publish-en_us.txt
@@ -1,0 +1,4 @@
+Help for: ds publish
+    
+    Run this command to publish your package to the registry specified in your
+    Package.toml.

--- a/cli/lib/commands/help-publish-en_us.txt
+++ b/cli/lib/commands/help-publish-en_us.txt
@@ -1,4 +1,4 @@
 Help for: ds publish
     
     Run this command to publish your package to the registry specified in your
-    Package.toml.
+    Package.toml. 

--- a/cli/lib/commands/help-whoami-en_us.txt
+++ b/cli/lib/commands/help-whoami-en_us.txt
@@ -1,0 +1,6 @@
+Help for: ds whoami [--registry=https://your.registry.here]
+    
+    Find out the username associated with the local token on a given registry.
+    Default registry is https://registry.entropic.dev; a different registry may
+    be passed with `--registry`. The URL for this registry must be a fully-
+    qualified domain name, including `https://`

--- a/cli/lib/commands/help.js
+++ b/cli/lib/commands/help.js
@@ -4,8 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 const readdirAsync = promisify(fs.readdir);
+const accessAsync = promisify(fs.access);
 
 const userHome = require('user-home');
+const getLocale = require('os-locale');
 
 module.exports = help;
 
@@ -14,8 +16,23 @@ async function help(opts) {
   if (!command) {
     await showBasicHelp();
   } else {
-    return new Promise((resolve, reject) => {
-      fs.createReadStream(path.join(__dirname, `help-${command}.txt`))
+    return new Promise(async (resolve, reject) => {
+      const locale = (await getLocale()).toLowerCase();
+      const localeFn = path.join(__dirname, `help-${command}-${locale}.txt`);
+      const defaultFn = path.join(__dirname, `help-${command}-en_us.txt`);
+      let fn = localeFn;
+
+      try {
+        await accessAsync(localeFn);
+      } catch (err) {
+        console.log(
+          `Could not find a help file for locale ${locale}, defaulting to English`
+        );
+        console.log(`You can contribute a translation for this help file!`);
+        fn = defaultFn;
+      }
+
+      fs.createReadStream(fn)
         .on('error', async err => {
           if (err.code === 'ENOENT') {
             console.log(

--- a/cli/lib/commands/login.js
+++ b/cli/lib/commands/login.js
@@ -14,7 +14,6 @@ const loginOpts = figgy({
 });
 
 async function login(opts) {
-  console.log(opts);
   opts = loginOpts(opts);
 
   const { username, token } = await profile.loginWeb(

--- a/cli/lib/commands/login.js
+++ b/cli/lib/commands/login.js
@@ -14,6 +14,7 @@ const loginOpts = figgy({
 });
 
 async function login(opts) {
+  console.log(opts);
   opts = loginOpts(opts);
 
   const { username, token } = await profile.loginWeb(

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
     "npm-profile": "^4.0.1",
     "npmlog": "^4.1.2",
     "opener": "^1.5.1",
+    "os-locale": "^3.1.0",
     "read-package-tree": "^5.2.2",
     "ssri": "^6.0.1",
     "user-home": "^2.0.0"


### PR DESCRIPTION
Provide a way to determine the locale of the user and load in a
localized help file, defaulting to english.

Add example help file from #111