### PR TITLE
Change the wording of "reverse isms" in the COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -39,7 +39,7 @@ Examples of unacceptable behavior by participants include:
   * Publishing private screenshots or quotes of interactions in the context of this project without all quoted users' *explicit* consent.
   * Publishing of private communication that doesn't have to do with reporting harassment.
   * Any of the above even when [presented as "ironic" or "joking"](https://en.wikipedia.org/wiki/Hipster_racism).
-  * Any attempt to present "reverse-ism" versions of the above as violations. Examples of reverse-isms are "reverse racism", "reverse sexism", "heterophobia", and "cisphobia".
+  * Attacks on any race or gender basis are equally unacceptable. There is no such thing as "reverse racism" or "reverse sexism"; that would be just racism and sexism, respectively.
   * Unsolicited explanations under the assumption that someone doesn't already know it. Ask before you teach! Don't assume what people's knowledge gaps are.
   * [Feigning or exaggerating surprise](https://www.recurse.com/manual#no-feigned-surprise) when someone admits to not knowing something.
   * "[Well-actuallies](https://www.recurse.com/manual#no-well-actuallys)"


### PR DESCRIPTION
I realize that the current COC is boilerplate, but the amended line basically encourages/deems acceptable discriminating against white people (the "reverse racism" part). I think it is appropriate to reword it to explicitly condemn racism and sexism as a whole, without the otherwise implied cherry-picking of racial/gender groups that are allowed to be discriminated against.

An example of a solid COC is actually linked from the current boilerplate:
- https://www.recurse.com/manual
- https://www.recurse.com/code-of-conduct
