### PR TITLE
Fix boltzmann authneeded response; Make local NODE_ENV consistent

### DIFF
--- a/services/common/boltzmann/response.js
+++ b/services/common/boltzmann/response.js
@@ -88,6 +88,6 @@ function authneeded(message, status = 401, extraHeaders = {}) {
   if (typeof message === 'string') {
     message = { error: message };
   }
-  const r = new Response(JSON.stringify(message), status, headers);
+  const r = new Response(JSON.stringify(message), { status, headers });
   return r;
 }

--- a/services/registry/.env-example
+++ b/services/registry/.env-example
@@ -1,4 +1,4 @@
-NODE_ENV=development
+NODE_ENV=dev
 DEV_LATENCY_ERROR_MS=10000
 POSTGRES_URL=postgres://postgres@db:5432
 PGHOST=db

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -20,7 +20,7 @@ Entropic reads all of its configuration from environment variables. You may prov
 
 Here are the config values and what they mean:
 
-* `NODE_ENV=env`: one of `development`, `testing`, or `production`
+* `NODE_ENV=env`: one of `dev`, `testing`, or `production`
 * `DEV_LATENCY_ERROR_MS=10000`: if a middleware is slower than this in development, you'll see warning logs
 * `POSTGRES_URL=postgres://postgres@127.0.0.1:5432`: postgresql connection string
 * `PORT=3000`: the port for the registry service to listen on


### PR DESCRIPTION
Spotted a few things while working on #118 

- `status` and `headers` were passed to `Response` constructor as separate arguments. Should be a `ResponseInit` object instead. Because of that currently https://registry.entropic.dev/v1/auth/whoami returns 200 when `authneeded`. Closes #129
- Different NODE_ENVs (`dev` and `development`) in start scripts for local environment were causing issues when I was trying to run the registry thing locally. As [the docs suggest](https://github.com/entropic-dev/entropic/blob/master/services/registry/README.md#running-your-own-registry) that there are only three envs supported at the moment, I switched `dev` to `development`. Closes #127 