### PR TITLE
[CLI] - validate commands and exit if invalid

### DIFF
--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -7,10 +7,17 @@ module.exports = main;
 const minimist = require('minimist');
 
 const { load } = require('./config');
+const { getValidCommandSet } = require('./utils');
 
 async function main(argv) {
   if (!argv[0]) {
     argv[0] = 'help';
+  }
+
+  const validCommand = (await getValidCommandSet()).has(argv[0]);
+  if (!validCommand) {
+    console.error(`${argv[0]} is not a valid command or option`);
+    return 0;
   }
 
   try {

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -1,0 +1,14 @@
+module.exports = { getValidCommandSet };
+
+const fs = require('fs').promises;
+
+/**
+ * Returns a set of files without file extensions from lib/commands
+ */
+async function getValidCommandSet() {
+  return new Set(
+    (await fs.readdir('./lib/commands')).map(filename => {
+      return filename.split('.')[0];
+    })
+  );
+}


### PR DESCRIPTION
### Issue
The CLI should not crash when given an invalid command. Found this when playing around with the registry.

![DeepinScreenshot_select-area_20190605102813](https://user-images.githubusercontent.com/1470297/58923914-a7a7d780-877c-11e9-8c0e-51ca3ea0b116.png)


### Proposal
Validate commands before attempting to require the module

### Tests
Adding a test would be dependent upon #118. I can create an empty file with a `#TODO` or open an issue.

