### PR TITLE
fix(docs): language in readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ on the resources of administrators.
 
 # Assumptions / Decisions / The Chem in the Golem's Head
 
-- Do the dumbest thing that works, then iterate on that as it breaks. KISS.
+- Do the simplest thing that works, then iterate on that as it breaks.
 - We will build a new registry and website.
 - INSTALLERS will be able to access VCPM packages through the registry, on demand.
     - Note: this implies we will mirror on-demand, not optimistically.


### PR DESCRIPTION
Hi team, really excited about your work here.

I changed "dumbest" to "simplest" in your README. Where I live (UK) and as a disabled person, "dumbest" does not lend itself to upholding the 

> Using welcoming and inclusive language.

statement in your Code of Conduct. 

> These terms can be associated with a person’s identity or their challenges, and because of that, can be interpreted as insulting or hurtful. And every time people use them, they reinforce the idea that people with disabilities are somehow inferior. 
- http://deareverybody.hollandbloorview.ca/resources/tips-and-tools/how-to-avoid-using-ableist-language/

I removed KISS as though it is an extremely common acronym, it also lends itself to not

> Using welcoming and inclusive language.

Also, it was not grammatically necessary to your statement.

---

A lot of words for a two word change, but there are a lot of :eyes: on this project and Open Source is not necessarily always a welcoming environment. So, best to come prepared.

Thanks, and good luck!