### PR TITLE
Add mocha to eslintrc env

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "parser": "babel-eslint",
   "parserOptions": {


### PR DESCRIPTION
Registry builds are currently failing on #132 due to mocha not being set in the `eslintrc` env. This Pr fixes that

![DeepinScreenshot_select-area_20190605220828](https://user-images.githubusercontent.com/1470297/58959065-364d4080-87df-11e9-969b-b95a00a2648b.png)
