### PR TITLE
[fix] Handle build with no depedencies

### DIFF
--- a/cli/lib/commands/build.js
+++ b/cli/lib/commands/build.js
@@ -117,6 +117,7 @@ async function buildFromMeta(opts, meta, loadingFiles, now = Date.now()) {
   const toplevel = { installed: {}, parent: null, name: 'root' };
 
   // todo list of "canonical dep name", "range", tree tier
+  content.dependencies = content.dependencies || {};
   const todo = Object.entries(content.dependencies).map(xs => [
     parsePackageSpec(xs[0], defaultHost),
     xs[1],


### PR DESCRIPTION
running `ds build` in a directory with no dependencies causes the
installer to crash since it can't convert undefined to an object.

closes #155