### PR TITLE
feat(cli): alias -v to --version

### DIFF
--- a/cli/lib/commands/-v.js
+++ b/cli/lib/commands/-v.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = v;
+
+function v() {
+  require('./--version')();
+}


### PR DESCRIPTION
I've typed `ds -v` a handful of times today, coming from a world of `node -v` and `npm -v`.
There were a couple ways I could have done this but I settled on this one.

```
~/projects/entropic/cli
❯ node lib/main.js 
Usage: ds <command>

Available commands:
        --version
        -v
       [list of other commands]
```

```
~/projects/entropic/cli 
❯ node lib/main.js -v
v1.0.0
```

:seedling: