### PR TITLE
fix(services/registry): check if namespace was found before going to the next middleware

### DIFF
--- a/services/registry/handlers/namespaces.js
+++ b/services/registry/handlers/namespaces.js
@@ -70,6 +70,13 @@ function findNamespace(next) {
       })
       .catch(Namespace.objects.NotFound, () => null);
 
+    if (!ns) {
+      return response.error(
+        `${params.namespace}@${params.host} does not exist.`,
+        404
+      );
+    }
+
     context.namespace = ns;
     return next(context, params);
   };


### PR DESCRIPTION
I traced #158 to `findNamespace` method that was proceeding with the next middleware even if the namespace was not found. I'm not sure if this was intentional or not. If it was, I guess this check needs to be moved to the end handlers

Closes #158