### PR TITLE
chore: Allow "a" in markdown

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,7 +10,11 @@
     "MD026": false,
     "MD028": false,
     "MD029": false,
-    "MD033": false,
+    "MD033": {
+        "allowed_elements": [
+            "a"
+        ]
+    },
     "MD034": false,
     "MD040": false,
     "MD038": false


### PR DESCRIPTION

Used for the alternate TOC in Contributing.md