### PR TITLE
Add the entropic-cache directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ allowed-list
 .DS_STORE
 *~
 *.swp
+services/data/entropic-cache


### PR DESCRIPTION
Useful when developing locally to ensure you don't commit cache content, and hides the cached content in many text editors.