### PR TITLE
Make Code of Conduct more visible in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+Before contributing, please take a moment to familiarise yourself with our [Code of Conduct](CODE_OF_CONDUCT.md). We expect everyone to follow it (and help enforce it) so that we can create a welcoming, open environment for everyone involved ✨😊✨
+
 ## How do I... <a name="toc"></a>
 
 * [Use This Guide](#introduction)?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Entropic: a federated package registry for anything
-[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors) [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 
 A new package registry with a new CLI, designed to be easy to stand up inside your network. Entropic features an entirely new file-centric API and a content-addressable storage system that attempts to minimize the amount of data you must retrieve over a network. This file-centric approach also applies to the publication API. See the [API section of the manifesto](https://github.com/entropic-dev/entropic/tree/master/docs#apis) for more details about the API offered.
 


### PR DESCRIPTION
This is my first OSS contribution so hopefully I've done this right.

I was reading the docs and specifically the contributing guidelines and thought, "I could contribute by adding a COC!" Then I realise it was already a file in the repo, but really isn't mentioned anywhere else. I think it's important to make these things as visible as possible so everyone is aware of them, so I wanted to add:

1) A badge to the top of the README saying we have a COC and linking to it
2) A blurb at the very top of the contributors doc to especially make people thinking of contributing aware of the COC

In opening this PR, I realise this now pops up on Github when you open your first PR but I think the more places we make it visible, the better 😊