### PR TITLE
docs: use string URL for repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "entropic",
   "description": "A new package registry with a new CLI, designed to be easy to stand up inside your network.",
+  "repository": "https://github.com/entropic-dev/entropic",
   "version": "1.0.0",
   "author": "C J Silverio <ceejceej@gmail.com>",
   "bugs": {
@@ -23,10 +24,6 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "private": true,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/entropic-dev/entropic.git"
-  },
   "scripts": {
     "lint": "npm run lint-registry && npm run lint-cli && npm run lint-md",
     "lint-cli": "cd cli; npm run lint",


### PR DESCRIPTION
Hello! I'm very excited about this new project.

This tiny PR updates the format of `repository` in the package.json file, changing it from an object to an HTTPS URL string. This format is easier to read, can be copy-pasted into the browser, can be used to `git clone` from the terminal, and is still compatible with [npm's package.json rules](https://docs.npmjs.com/files/package.json#repository).