### PR TITLE
fix(services/common/boltzmann): Change body.error to body.message

### DIFF
--- a/services/common/boltzmann/response.js
+++ b/services/common/boltzmann/response.js
@@ -86,7 +86,7 @@ function authneeded(message, status = 401, extraHeaders = {}) {
     ...extraHeaders
   });
   if (typeof message === 'string') {
-    message = { error: message };
+    message = { message, code: 'EAUTHNEEDED' };
   }
   const r = new Response(JSON.stringify(message), { status, headers });
   return r;


### PR DESCRIPTION
Fixes an issue mentioned by @chrisdickinson in https://github.com/entropic-dev/entropic/pull/118#discussion_r290907013

> if we're using body.error someplace that's a mistake on the server side – we should fix that.