### PR TITLE
Add lint and fail phase for root lint script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "lint": "npm run lint-registry && npm run lint-cli && npm run lint-md",
+    "lint": "npm run lint-registry && npm run lint-cli && npm run lint-js && npm run lint-md",
     "lint-cli": "cd cli; npm run lint",
     "lint-fix": "prettier --write '**/*.js'",
+    "lint-js": "prettier --check '**/*.js'",
     "lint-md": "markdownlint \"**/*.md\" -i \"**/node_modules/**\"",
     "lint-registry": "cd services/registry; npm run lint",
     "postinstall": "for d in cli services/{registry,workers,web,common/boltzmann}; do cd $d; npm i; cd -; done",


### PR DESCRIPTION
This should prevent any lint failing code to pass in presubmit prior to
the code being landed in source control.

---

Note: currently lint is not set to run during presubmit, however we can enable this! Doing this class of enable will be a `large-scale-change` by running prettier to reformat all code prior to enabling the lint to minimize code-churn for all contributors. 