### PR TITLE
Remove unused pipeline import from vcpm-sync.

### DIFF
--- a/tools/vcpm-sync/main.js
+++ b/tools/vcpm-sync/main.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const { pipeline } = require('stream');
 const FormData = require('form-data');
 const minimist = require('minimist');
 const fetch = require('node-fetch');


### PR DESCRIPTION
This is a NOOP change, and removes an unused import from the vcpm sync.