### PR TITLE
feat(cli): show authentication URL during `ds login`

### DIFF
--- a/cli/lib/commands/login.js
+++ b/cli/lib/commands/login.js
@@ -18,7 +18,7 @@ async function login(opts) {
 
   const { username, token } = await profile.loginWeb(
     async url => {
-      console.log(`Opening ${url} in default browser...`);
+      console.log(`Here's your login url:\n  ${url}\nA browser window should open momentarily (If it doesn't, open the above link manually.)`);
       return opener(url);
     },
     opts

--- a/cli/lib/commands/login.js
+++ b/cli/lib/commands/login.js
@@ -17,7 +17,10 @@ async function login(opts) {
   opts = loginOpts(opts);
 
   const { username, token } = await profile.loginWeb(
-    async u => opener(u),
+    async url => {
+      console.log(`Opening ${url} in default browser...`);
+      return opener(url);
+    },
     opts
   );
 


### PR DESCRIPTION
In some circumstances, `opener` could not open an authentication URL.

This change ensures user has some way of knowing what's expected of him
to successfully finish authentication process.

# Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

```
gitpod /workspace/entropic/cli $ node lib/main.js login
http fetch POST 200 https://registry.entropic.dev/-/v1/login 592ms
Opening https://registry.entropic.dev/www/login?cli=11e54830-2bd3-462f-b2a4-426323060915 in default browser...
http fetch GET 202 https://registry.entropic.dev/-/v1/login/poll/11e54830-2bd3-462f-b2a4-426323060915 143ms
http fetch GET 202 https://registry.entropic.dev/-/v1/login/poll/11e54830-2bd3-462f-b2a4-426323060915 142ms
http fetch GET 202 https://registry.entropic.dev/-/v1/login/poll/11e54830-2bd3-462f-b2a4-426323060915 142ms
http fetch GET 200 https://registry.entropic.dev/-/v1/login/poll/11e54830-2bd3-462f-b2a4-426323060915 146ms
```

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
