### PR TITLE
feat(ci): pack cli during ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,15 @@ jobs:
 
       - run: npm test
 
+      - run:
+          name: npm pack
+          command: |
+            mkdir -p /tmp/artifacts
+            cd /tmp/artifacts
+            npm pack ~/repo/cli
+      - store_artifacts:
+          path: /tmp/artifacts
+
 workflows:
   version: 2
   everything:


### PR DESCRIPTION
Add another step during CLI CI process to pack the latest version of the pack and put it in CircleCI Artifacts.

The artifacts are available publicly, without having to use CircleCI tokens and allow you to quickly install truly "latest" package. Installation one-liner could be further changed to allow installation of specific version of `ds` tool by providing CircleCI build number of the build or by querying the CircleCI API for the latest `master` build.

# Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

To try it out,
1)  Open CircleCI build (https://circleci.com/gh/enykeev/entropic/7#artifacts/containers/0)
2) Go to Artifacts tab
3) Expand `> artifacts`
4) Copy file location (https://7-191097591-gh.circle-artifacts.com/0/tmp/artifacts/ds-1.0.0.tgz)
5) Paste it into `npm install -g [url]` command

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
