### PR TITLE
[CLI] - Catch cli up Pt. 1

### DIFF
--- a/cli/lib/api.js
+++ b/cli/lib/api.js
@@ -1,0 +1,25 @@
+const fetch = require('node-fetch');
+
+class Api {
+  constructor(baseUrl, token) {
+    this.baseUrl = baseUrl;
+  }
+
+  headers(token) {
+    return {
+      authorization: `Bearer ${token}`
+    };
+  }
+
+  async whoami(token) {
+    return await fetch(`${this.baseUrl}/v1/auth/whoami`, {
+      headers: this.headers(token)
+    });
+  }
+
+  
+}
+
+module.exports = {
+  Api
+};

--- a/cli/lib/api.js
+++ b/cli/lib/api.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 
 class Api {
-  constructor(baseUrl, token) {
+  constructor(baseUrl) {
     this.baseUrl = baseUrl;
   }
 

--- a/cli/lib/api.js
+++ b/cli/lib/api.js
@@ -16,8 +16,6 @@ class Api {
       headers: this.headers(token)
     });
   }
-
-  
 }
 
 module.exports = {

--- a/cli/lib/api.js
+++ b/cli/lib/api.js
@@ -11,7 +11,7 @@ class Api {
     };
   }
 
-  whoami(token) {
+  whoAmI(token) {
     return fetch(`${this.baseUrl}/v1/auth/whoami`, {
       headers: this.headers(token)
     });

--- a/cli/lib/api.js
+++ b/cli/lib/api.js
@@ -11,13 +11,11 @@ class Api {
     };
   }
 
-  async whoami(token) {
-    return await fetch(`${this.baseUrl}/v1/auth/whoami`, {
+  whoami(token) {
+    return fetch(`${this.baseUrl}/v1/auth/whoami`, {
       headers: this.headers(token)
     });
   }
 }
 
-module.exports = {
-  Api
-};
+module.exports = Api;

--- a/cli/lib/commands/whoami.js
+++ b/cli/lib/commands/whoami.js
@@ -8,7 +8,8 @@ const { whoAmI } = require('../utils');
 const whoamiOpts = figgy({
   registry: { default: 'https://registry.entropic.dev' },
   token: true,
-  log: { default: require('npmlog') }
+  log: { default: require('npmlog') },
+  api: true
 });
 
 async function whoami(opts) {

--- a/cli/lib/commands/whoami.js
+++ b/cli/lib/commands/whoami.js
@@ -17,7 +17,6 @@ async function whoami(opts) {
 
   try {
     const username = await whoAmI();
-
     console.log(username);
     return 0;
   } catch (err) {

--- a/cli/lib/commands/whoami.js
+++ b/cli/lib/commands/whoami.js
@@ -8,7 +8,7 @@ const { whoAmI } = require('../utils');
 const whoamiOpts = figgy({
   registry: { default: 'https://registry.entropic.dev' },
   token: true,
-  log: { default: require('npmlog') },
+  log: true,
   api: true
 });
 
@@ -16,11 +16,11 @@ async function whoami(opts) {
   opts = whoamiOpts(opts);
 
   try {
-    const username = await whoAmI();
-    console.log(username);
+    const username = await whoAmI(opts);
+    opts.log.log(username);
     return 0;
   } catch (err) {
-    console.log(err.message);
+    opts.log.error(err.message, err);
     return 1;
   }
 }

--- a/cli/lib/logger.js
+++ b/cli/lib/logger.js
@@ -1,0 +1,16 @@
+const chalk = require('chalk');
+
+module.exports = class Logger {
+  static log(msg) {
+    console.log(chalk.default.yellow(msg));
+  }
+  static error(msg, stacktrace = undefined) {
+    console.log(chalk.default.red(msg));
+
+    // Don't print the stacktrace in red. That
+    // would be overwhelming
+    if (stacktrace) {
+      console.log(stacktrace);
+    }
+  }
+};

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -7,7 +7,7 @@ module.exports = main;
 const minimist = require('minimist');
 
 const { load } = require('./config');
-const { Api } = require('./api');
+const Api = require('./api');
 
 async function main(argv) {
   if (!argv[0]) {

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -8,6 +8,7 @@ const minimist = require('minimist');
 
 const { load } = require('./config');
 const Api = require('./api');
+const log = require('./logger');
 
 async function main(argv) {
   if (!argv[0]) {
@@ -44,7 +45,8 @@ async function main(argv) {
       ...registryConfig,
       ...args,
       argv: _,
-      api: new Api(registry)
+      api: new Api(registry),
+      log
     });
 
     return 0;

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -32,11 +32,7 @@ async function main(argv) {
       }
     }
 
-    const registry =
-      args.registry ||
-      config.registry ||
-      env.registry ||
-      'https://registry.entropic.dev';
+    const registry = args.registry || config.registry || env.registry || 'https://registry.entropic.dev';
 
     const registryConfig = (config.registries || {})[registry] || {};
 

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -7,6 +7,7 @@ module.exports = main;
 const minimist = require('minimist');
 
 const { load } = require('./config');
+const { Api } = require('./api');
 
 async function main(argv) {
   if (!argv[0]) {
@@ -41,7 +42,14 @@ async function main(argv) {
 
     // env is overridden by config, which is overridden by registry-specific
     // config, ...
-    await cmd({ ...env, ...config, ...registryConfig, ...args, argv: _ });
+    await cmd({
+      ...env,
+      ...config,
+      ...registryConfig,
+      ...args,
+      argv: _,
+      api: new Api(registry)
+    });
 
     return 0;
   } catch (err) {

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -1,26 +1,16 @@
-const fetch = require('./fetch');
-
-module.exports.whoAmI = async ({ registries = {}, registry, token }) => {
-  const r = registries[registry];
-
-  if (r.username) return r.username;
-
-  const response = await fetch(`${registry}/v1/auth/whoami`, {
-    headers: {
-      authorization: `Bearer ${token}`
-    }
-  });
+module.exports.whoAmI = async ({ registry, token, api }) => {
+  const response = await api.whoAmI(token);
 
   let body = null;
   try {
     body = await response.json();
   } catch (err) {
-    throw new Error(`Caught error requesting "${registry}/v1/auth/whoami"`)
+    throw new Error(`Caught error requesting "${registry}/v1/auth/whoami"`);
   }
 
   if (response.status > 399) {
-    throw new Error(body.message || body)
+    throw new Error(body.message || body);
   }
 
   return body.username;
-}
+};

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -390,6 +390,42 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -600,6 +636,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-union": {
@@ -3645,6 +3687,12 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3785,6 +3833,12 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "loud-rejection": {
       "version": "2.1.0",
@@ -4240,6 +4294,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -4709,6 +4776,23 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -5393,6 +5477,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6032,6 +6131,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -51,7 +51,8 @@
     "eslint-plugin-prettier": "~3.1.0",
     "mocha": "~6.1.4",
     "must": "~0.13.4",
-    "prettier": "~1.17.1"
+    "prettier": "~1.17.1",
+    "sinon": "^7.3.2"
   },
   "directories": {
     "lib": "lib"
@@ -70,6 +71,6 @@
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "prettier --write '**/*.js'",
-    "test": "mocha -R spec"
+    "test": "ava"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -72,5 +72,16 @@
     "lint": "eslint .",
     "lint-fix": "prettier --write '**/*.js'",
     "test": "ava"
-  }
+  },
+    "ava": {
+      "files": [
+        "test/**/*"
+      ],
+      "helpers": [
+        "test/utils/**/*"
+      ],
+      "sources": [
+        "lib/**/*"
+      ]
+    }
 }

--- a/cli/test/01-cli.js
+++ b/cli/test/01-cli.js
@@ -1,8 +1,0 @@
-/* eslint-env node, mocha */
-'use strict';
-
-const demand = require('must');
-
-describe('ds', () => {
-  it('has tests');
-});

--- a/cli/test/lib/commands/whoami.js
+++ b/cli/test/lib/commands/whoami.js
@@ -1,0 +1,36 @@
+const test = require('ava');
+const whoami = require('../../../lib/commands/whoami');
+const sinon = require('sinon');
+
+const FakeApi = require('../../utils/FakeApi');
+
+test('whoami calls console.log with username when API response is successful', async t => {
+  const consoleLog = sinon.stub(console, 'log');
+
+  const username = 'RaynorJim';
+
+  // TODO ... we shouldn't be using console.log directly
+  await whoami({
+    api: new FakeApi({ username }, 200)
+  });
+
+  t.is(consoleLog.calledOnce, true);
+  t.is(consoleLog.calledWith(`username: ${username}`), true);
+  consoleLog.restore();
+});
+
+test('whoami calls error when not successful', async t => {
+  const logger = {
+    error() {}
+  };
+  const stubbedLogger = sinon.stub(logger, 'error');
+
+  const error = 'You are forbidden!';
+
+  await whoami({
+    log: logger,
+    api: new FakeApi({ message: error }, 403)
+  });
+
+  t.is(stubbedLogger.calledWith(error), true);
+});

--- a/cli/test/lib/commands/whoami.js
+++ b/cli/test/lib/commands/whoami.js
@@ -5,30 +5,25 @@ const sinon = require('sinon');
 const FakeApi = require('../../utils/FakeApi');
 
 test('whoami calls console.log with username when API response is successful', async t => {
-  const consoleLog = sinon.stub(console, 'log');
+  const log = sinon.stub(FakeLogger, 'log');
 
   const username = 'RaynorJim';
-
-  // TODO ... we shouldn't be using console.log directly
   await whoami({
+    log: FakeLogger,
     api: new FakeApi({ username }, 200)
   });
 
-  t.is(consoleLog.calledOnce, true);
-  t.is(consoleLog.calledWith(`username: ${username}`), true);
-  consoleLog.restore();
+  t.is(log.calledWith(username), true);
+  log.restore();
 });
 
 test('whoami calls error when not successful', async t => {
-  const logger = {
-    error() {}
-  };
-  const stubbedLogger = sinon.stub(logger, 'error');
+  const stubbedLogger = sinon.stub(FakeLogger, 'error');
 
   const error = 'You are forbidden!';
 
   await whoami({
-    log: logger,
+    log: FakeLogger,
     api: new FakeApi({ message: error }, 403)
   });
 

--- a/cli/test/lib/commands/whoami.js
+++ b/cli/test/lib/commands/whoami.js
@@ -3,6 +3,7 @@ const whoami = require('../../../lib/commands/whoami');
 const sinon = require('sinon');
 
 const FakeApi = require('../../utils/FakeApi');
+const FakeLogger = require('../../utils/FakeLogger');
 
 test('whoami calls console.log with username when API response is successful', async t => {
   const log = sinon.stub(FakeLogger, 'log');

--- a/cli/test/utils/FakeApi.js
+++ b/cli/test/utils/FakeApi.js
@@ -1,0 +1,18 @@
+class FakeApi {
+  constructor(response, status) {
+    this.desiredResponse = response;
+    this.desiredStatus = status;
+  }
+
+  async whoami() {
+    return new Promise((resolve, reject) => {
+      resolve({
+        status: this.desiredStatus,
+        message: 'OK',
+        json: () => new Promise((jsonRes, _jsonRej) => jsonRes(this.desiredResponse))
+      });
+    });
+  }
+}
+
+module.exports = FakeApi;

--- a/cli/test/utils/FakeApi.js
+++ b/cli/test/utils/FakeApi.js
@@ -1,10 +1,10 @@
-class FakeApi {
+module.exports = class FakeApi {
   constructor(response, status) {
     this.desiredResponse = response;
     this.desiredStatus = status;
   }
 
-  async whoami() {
+  async whoAmI() {
     return new Promise((resolve, reject) => {
       resolve({
         status: this.desiredStatus,
@@ -13,6 +13,4 @@ class FakeApi {
       });
     });
   }
-}
-
-module.exports = FakeApi;
+};

--- a/cli/test/utils/FakeLogger.js
+++ b/cli/test/utils/FakeLogger.js
@@ -1,0 +1,4 @@
+module.exports = class FakeLogger {
+  static log() {}
+  static error() {}
+};


### PR DESCRIPTION
## Description
This is the first part of the large CLI refactor post #135 merge. The plan is to basically abstract fetch calls to a common API wrapper and mock those responses for easy testing. The wrapper will also be injected at runtime alongside the other options. This also adds `sinon` for spying / mocking / etc. 

`whoami` was just the easiest command that had the least amount of code to change to get this process started

Subsequent PRs will / should ( _potential good newcomer task?_ ) move the fetch from the command and into the API wrapper. Future PR's need to take heed to [this comment](https://github.com/entropic-dev/entropic/pull/135#issuecomment-500102315), specifically the URL changes

Related #217

## How to test
- Pull this branch down: `git fetch origin pull/234/head:pr-234` ( _where origin is your entropic remote_ )
- `cd` to `cli`
- Make sure you're logged in `node ./lib/main.js login`
- Run `node ./lib/main.js whoami`

You can link the `ds` to your current branch by running `npm link` in the `cli` directory, but I prefer to keep mine separate.
