### PR TITLE
Add engines field for ds

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,9 @@
     "type": "git",
     "url": "git://github.com/entopic-dev/entropic.git"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "prettier --write '**/*.js'",

--- a/misc/install.sh
+++ b/misc/install.sh
@@ -12,4 +12,5 @@ else
   exit 1
 fi
 
-npm install -g ds-latest.tgz
+# engine-strict config forces checking against engines.node version constraint
+NPM_CONFIG_ENGINE_STRICT=true npm install -g ds-latest.tgz


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

As per the readme, the `ds` CLI only runs in NodeJS v12, so this change adds a `engines.node` to ds's `package.json` restricting it to >=12, and uses the `NPM_CONFIG_ENGINE_STRICT` environment variable in `misc/install.sh` to temporarily enforce strict engine checking in `npm` when installing the client.

My reasoning here is that when pulling down the client users may be installing onto older linuxes (such as Ubuntu 16.04) with ancient node versions that need PPAs or other sources to get v12 installed, and that by allowing the install to progress without any warnings could just result in lots more erroneous bugs and general confusion.

# Checklist

* [ ] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
