### PR TITLE
docs(README): Fixed links in README to the contributing guide and the CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Entropic: a federated package registry for anything
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square)](#contributors) [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat-square)](CODE_OF_CONDUCT.md)
+[![All Contributors](https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square)](#contributors) [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat-square)](./.github/CODE_OF_CONDUCT.md)
 
 A new package registry with a new CLI, designed to be easy to stand up inside your network. Entropic features an entirely new file-centric API and a content-addressable storage system that attempts to minimize the amount of data you must retrieve over a network. This file-centric approach also applies to the publication API. See the [API section of the manifesto](https://github.com/entropic-dev/entropic/tree/master/docs#apis) for more details about the API offered.
 
@@ -76,9 +76,9 @@ Publish a new package-version with `ds publish`.
 
 ## Contributing
 
-Entropic is, at the moment of this writing, the work of two people: [Chris Dickinson](https://github.com/chrisdickinson) and [C J Silverio](https://github.com/ceejbot). They are not sponsored by anybody nor do they represent anyone but themselves. Chris and Ceej are seeking additional contributors but wish to onboard newcomers slowly. The project is new enough that clear direction does not always exist in the code, so contributors will need to work closely with us. Read [CONTRIBUTING guide](./CONTRIBUTING.md)
+Entropic is, at the moment of this writing, the work of two people: [Chris Dickinson](https://github.com/chrisdickinson) and [C J Silverio](https://github.com/ceejbot). They are not sponsored by anybody nor do they represent anyone but themselves. Chris and Ceej are seeking additional contributors but wish to onboard newcomers slowly. The project is new enough that clear direction does not always exist in the code, so contributors will need to work closely with us. Read the [CONTRIBUTING guide](./.github/CONTRIBUTING.md).
 
-For more, see [Contributing](./.github/CONTRIBUTING.md) and our [Code of Conduct](./.github/CODE_OF_CONDUCT.md).
+For more, see the [Contributing guide](./.github/CONTRIBUTING.md) and our [Code of Conduct](./.github/CODE_OF_CONDUCT.md).
 
 ## Contributors
 


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

Hi all! I noticed that some of the links in the README to .github files were broken. This PR fixes the broken links that I could find:
* The Code of Conduct badge at the top of the document
* A link to the Contributing guide in the Contributing section 

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
    * Demo here: https://github.com/SammyIsra/entropic/blob/updateReadmeLinks/README.md