### PR TITLE
Chris/fix docker compose and url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# docker-compose is provided for development purposes only and is not
+# intended for use as a production entropic setup.
 version: '3.1'
 services:
   db:
@@ -39,6 +41,12 @@ services:
       - "3000:3000"
     env_file:
       - ./services/registry/.env
+    environment:
+      STORAGE_API_URL: http://storage:3002
+      PORT: 3000
+      WEB_HOST: http://localhost:3001
+      REDIS_URL: redis://redis:6379
+      EXTERNAL_HOST: http://localhost:3000
 
   web:
     image: mhart/alpine-node:12
@@ -52,6 +60,12 @@ services:
       - "3001:3001"
     env_file:
       - ./services/web/.env
+    environment:
+      STORAGE_API_URL: http://storage:3002
+      PORT: 3001
+      WEB_HOST: http://localhost:3001
+      REDIS_URL: redis://redis:6379
+      EXTERNAL_HOST: http://localhost:3001
 
   storage:
     image: mhart/alpine-node:12
@@ -66,6 +80,13 @@ services:
     #  - "3002:3002"
     env_file:
       - ./services/storage/.env
+    environment:
+      POSTGRES_URL: postgres://postgres@db:5432
+      PGHOST: db
+      REDIS_URL: redis://redis:6379
+      PORT: 3002
+      PGUSER: postgres
+      PGDATABASE: entorpic_dev
 
 volumes:
   postgres_data:

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "lint-fix": "prettier --write '**/*.js'",
     "lint-md": "markdownlint \"**/*.md\" -i \"**/node_modules/**\"",
     "lint-registry": "cd services/registry; npm run lint",
-    "postinstall": "for d in cli services/{registry,workers,web,common/boltzmann}; do cd $d; npm i; cd -; done",
+    "postinstall": "for d in cli services/{registry,workers,web,storage,common/boltzmann}; do cd $d; npm i; cd -; done",
     "start": "docker-compose up",
-    "test": "for d in cli services/{registry,workers,web,common/boltzmann}; do cd $d; npm t; cd -; done"
+    "test": "for d in cli services/{registry,workers,web,storage,common/boltzmann}; do cd $d; npm t; cd -; done"
   }
 }

--- a/services/common/boltzmann/request-handler.js
+++ b/services/common/boltzmann/request-handler.js
@@ -29,7 +29,7 @@ class Context {
     if (this._parsedUrl) {
       return this._parsedUrl;
     }
-    this._parsedUrl = new URL(this.request.url);
+    this._parsedUrl = new URL(this.request.url, 'http://entropic.dev');
     return this._parsedUrl;
   }
 }

--- a/services/registry/handlers/maintainers.js
+++ b/services/registry/handlers/maintainers.js
@@ -25,8 +25,8 @@ async function maintainers(context, { namespace, host, name }) {
       host,
       name,
       bearer: context.user ? context.user.name : null,
-      page: Number(context.url.query.page) || 0,
-      status: context.url.query.status
+      page: Number(context.url.searchParams.get('page')) || 0,
+      status: context.url.searchParams.get('status')
     })
     .then(xs => [null, xs], xs => [xs, null]);
 

--- a/services/registry/handlers/namespaces.js
+++ b/services/registry/handlers/namespaces.js
@@ -31,7 +31,7 @@ module.exports = [
 async function namespaces(context, params) {
   const [err, result] = await context.storageApi
     .listNamespaces({
-      page: Number(context.url.query.page) || 0
+      page: Number(context.url.searchParams.get('page')) || 0
     })
     .then(xs => [null, xs], xs => [xs, null]);
 
@@ -47,9 +47,9 @@ async function namespaces(context, params) {
 async function members(context, { namespace, host }) {
   const [err, result] = await context.storageApi
     .listNamespaceMembers({
-      page: Number(context.url.query.page) || 0,
+      page: Number(context.url.searchParams.get('page')) || 0,
       bearer: context.user ? context.user.name : null,
-      status: context.url.query.status,
+      status: context.url.searchParams.get('status'),
       namespace,
       host
     })
@@ -131,10 +131,10 @@ async function remove(context, { invitee, namespace, host }) {
 async function memberships(context, { user }) {
   const [err, result] = await context.storageApi
     .listNamespaceMembers({
-      page: Number(context.url.query.page) || 0,
+      page: Number(context.url.searchParams.get('page')) || 0,
       for: user,
       bearer: context.user.name,
-      status: context.url.query.status
+      status: context.url.searchParams.get('status')
     })
     .then(xs => [null, xs], xs => [xs, null]);
 
@@ -150,8 +150,8 @@ async function memberships(context, { user }) {
 async function maintainerships(context, { namespace, host }) {
   const [err, result] = await context.storageApi
     .listNamespaceMaintainerships({
-      page: Number(context.url.query.page) || 0,
-      status: context.url.query.status,
+      page: Number(context.url.searchParams.get('page')) || 0,
+      status: context.url.searchParams.get('status'),
       namespace,
       host,
       bearer: context.user.name

--- a/services/registry/handlers/packages.js
+++ b/services/registry/handlers/packages.js
@@ -37,7 +37,7 @@ module.exports = [
 async function packageList(context) {
   const [err, result] = await context.storageApi
     .listPackages({
-      page: Number(context.url.query.page) || 0
+      page: Number(context.url.searchParams.get('page')) || 0
     })
     .then(xs => [null, xs], xs => [xs, null]);
 

--- a/services/registry/handlers/users.js
+++ b/services/registry/handlers/users.js
@@ -20,8 +20,8 @@ async function memberships(context, { username }) {
     .listUserMemberships({
       for: username,
       bearer: context.user.name,
-      page: context.url.query.page,
-      status: context.url.query.status
+      page: context.url.searchParams.get('page'),
+      status: context.url.searchParams.get('status')
     })
     .then(xs => [null, xs], xs => [xs, null]);
 

--- a/services/storage/handlers/users.js
+++ b/services/storage/handlers/users.js
@@ -32,7 +32,7 @@ async function tokens(context, { username }) {
   }
 
   const PER_PAGE = 100;
-  const offset = (Number(context.url.query.page) || 0) * PER_PAGE;
+  const offset = (Number(context.url.searchParams.get('page')) || 0) * PER_PAGE;
 
   const tokens = await Token.objects
     .filter({

--- a/services/web/handlers/auth.js
+++ b/services/web/handlers/auth.js
@@ -233,7 +233,7 @@ async function tokens(context) {
   const { objects: tokens } = await context.storageApi.listTokens({
     for: user,
     bearer: user,
-    page: Number(context.url.query.page) || 0
+    page: Number(context.url.searchParams.get('page')) || 0
   });
   const cliLoginSession = context.session.get('cli');
 


### PR DESCRIPTION
- Fixes `new URL`'s pickiness about needing a FQDN param if given a partial path.
- `new URL` spells `context.url.query.page` as `context.url.searchParams.get('page')`
- Add default docker environment values so that they all know about each other in docker-compose mode.
- Add an admonition that "we don't mean for you to deploy a production entropic using docker-compose."