### PR TITLE
fix: the `--version` and `-v` command were broken

### DIFF
--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -20,7 +20,11 @@ async function main(argv) {
 
     let cmd;
     try {
-      cmd = require(`./commands/${_.shift()}`);
+      if (args.version || args.v) {
+        cmd = require('./commands/--version');
+      } else {
+        cmd = require(`./commands/${_.shift()}`);
+      }
     } catch (e) {
       cmd = require('./commands/help');
     }


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

This is a tiny fix to the `--version` and `-v` commands as they were not working.

# Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
