### PR TITLE
fix(login): add noop for `logger.http`

### DIFF
--- a/cli/lib/logger.js
+++ b/cli/lib/logger.js
@@ -13,4 +13,5 @@ module.exports = class Logger {
       console.log(stacktrace);
     }
   }
+  static http(msg) {}
 };


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

I think a change in https://github.com/entropic-dev/entropic/commit/43310ef4c26ccaf1bc9b8c0b4e38975ae5205552 possibly broke the `login` command. `npm-registry-fetch` is bailing because there isn't a `log.http`. I noop'd it for now, but maybe it should be a debug log level and log the actual url of the fetch. 

```
$ node ./lib/main.js login
/Users/mike.matuzak/workspace/entropic/cli/node_modules/npm-registry-fetch/check-response.js:32
  opts.log.http(
           ^

TypeError: opts.log.http is not a function
    at logRequest (/Users/mike.matuzak/workspace/entropic/cli/node_modules/npm-registry-fetch/check-response.js:32:12)
    at PassThrough.<anonymous> (/Users/mike.matuzak/workspace/entropic/cli/node_modules/npm-registry-fetch/check-response.js:18:30)
    at PassThrough.emit (events.js:205:15)
    at endReadableNT (_stream_readable.js:1154:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:9)
```
# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
