### PR TITLE
[RFC] CLI localization story

### DIFF
--- a/cli/lib/commands/download.toml
+++ b/cli/lib/commands/download.toml
@@ -1,3 +1,6 @@
+[help]
+en_us = '''
 Help for: ds download
 
     Fetch & insert into cache the content blobs for the named package-version.
+'''

--- a/cli/lib/commands/help-login-en_us.txt
+++ b/cli/lib/commands/help-login-en_us.txt
@@ -1,7 +1,0 @@
-Help for: ds login
-    
-    Run this command to login to the preferred registry specified in your
-    ~/.entropicrc file. (Default: https://registry.entropic.dev). Running the 
-    command will open a browser window to authorize the registy access to
-    your Github account for authorization. Return to the terminal to complete
-    the login.

--- a/cli/lib/commands/invite.toml
+++ b/cli/lib/commands/invite.toml
@@ -1,5 +1,7 @@
+[help]
+en_us = '''
 Help for: ds invite [name] --to [pkg/namespace]
 
     Invite a namespace to join the maintainers list for a given package or 
     namespace.
-    
+'''

--- a/cli/lib/commands/login.toml
+++ b/cli/lib/commands/login.toml
@@ -1,0 +1,21 @@
+[help]
+
+default = '''
+Help for: ds login
+    
+    Run this command to login to the preferred registry specified in your
+    ~/.entropicrc file. (Default: https://registry.entropic.dev). Running the 
+    command will open a browser window to authorize the registy access to
+    your Github account for authorization. Return to the terminal to complete
+    the login.
+'''
+
+ru_ru = '''
+Помощь для команды: ds login
+
+    Используйте эту комманду для того что бы войти в реестр, указанный в вашем
+    файле ~/.entropicrc (по умолчанию: https://registry.entropic.dev). Вызов этой
+    команды откроет окно браузера для авторизации доступа указанного рееста к
+    вашему аккаунту GitHub. После подтверждения, вернитесь в терминал для завершения
+    входа.
+'''

--- a/cli/lib/commands/publish.toml
+++ b/cli/lib/commands/publish.toml
@@ -1,4 +1,7 @@
+[help]
+en_us = '''
 Help for: ds publish
     
     Run this command to publish your package to the registry specified in your
-    Package.toml. 
+    Package.toml.
+'''

--- a/cli/lib/commands/whoami.toml
+++ b/cli/lib/commands/whoami.toml
@@ -1,6 +1,9 @@
+[help]
+en_us = '''
 Help for: ds whoami [--registry=https://your.registry.here]
     
     Find out the username associated with the local token on a given registry.
     Default registry is https://registry.entropic.dev; a different registry may
     be passed with `--registry`. The URL for this registry must be a fully-
     qualified domain name, including `https://`
+'''

--- a/cli/lib/localization.js
+++ b/cli/lib/localization.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const toml = require('@iarna/toml');
+const osLocale = require('os-locale');
+
+module.exports = translate;
+
+let translations = null;
+let locale = null;
+
+const replace = (str, map) =>
+  str.replace(/\{{2}(\S+?)\}{2}/gi, (_, key) => {
+    if (key.startsWith('t:')) {
+      if (map[key.slice(2)]) {
+        return translate(map[key.slice(2)]);
+      } else {
+        return `{{${key.slice(2)}}}`;
+      }
+    } else {
+      return map[key] || `{{${key}}}`;
+    }
+  });
+
+function translate(key, substitutions = {}) {
+  if (!translations) {
+    translations = toml.parse(fs.readFileSync(path.resolve(__dirname, 'localization.toml'), 'utf8'));
+  }
+
+  if (!locale) {
+    locale = osLocale.sync().toLowerCase();
+  }
+
+  const str = translations[key] && translations[key][locale] ? translations[key][locale] : key;
+
+  return replace(str, substitutions);
+}

--- a/cli/lib/localization.toml
+++ b/cli/lib/localization.toml
@@ -1,0 +1,13 @@
+["Help for command \"{{command}}\" doesn't exist yet. You can help out by contributing!"]
+ru_ru = 'Помощь для команды "{{command}}" отсутвует. Вы можете помочь это исправить!'
+
+["This command help is not yet translated to {{t:locale}}. You can help out by contributing!"]
+ru_ru = "Помощь для этой команды еще не переведена на {{t:locale}}. Вы можете помочь это исправить!"
+
+["en_us"]
+en_us = "English"
+ru_ru = "английский"
+
+["ru_ru"]
+en_us = "Russian"
+ru_ru = "русский"

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -6,6 +6,8 @@ module.exports = main;
 
 const minimist = require('minimist');
 
+const helpCommand = require('./commands/help');
+
 const { load } = require('./config');
 const Api = require('./api');
 const log = require('./logger');
@@ -20,12 +22,20 @@ async function main(argv) {
     try {
       cmd = require(`./commands/${argv[0]}`);
     } catch (e) {
-      cmd = require('./commands/help');
+      cmd = helpCommand;
     }
 
     const { _, ...args } = minimist(argv.slice(1));
+
+    if (args.help === true) {
+      helpCommand({ argv });
+      return 0;
+    }
+
     const config = await load();
+
     const env = {};
+
     for (const key in process.env) {
       if (key.startsWith('ent_')) {
         env[key.slice(4)] = process.env[key];


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [ ] Bug Fix
* [x] RFC / Hopefully a feature 😄 

# Change Level

* [ ] major
* [x] minor
* [ ] patch

# Further Information (screenshots, bug report links, etc.)

This PR is a request for comment/feedback for a CLI structure in relation to localization that I was thinking about for a few days. I was reflecting on [this comment](https://discourse.entropic.dev/t/commander-js-for-cli-stuff/27/9?u=gribnoysup) by @ceejbot and this issue: https://github.com/entropic-dev/entropic/issues/115

So the implementation in this PR tries to follow a few things metnioned in the linked comment and issue:

- Moves translation strings out to configs so it's easier to integrate later with some fancy UI if needed
- Clear structure: commands all have a corresponsing toml file with help (and any other metadata if we need this for something else), as toml files are named as commands, they are nicely sorted together is a file tree. Common translation strings used across commands are in one separate file
- Easy to add translations
- Easy (opinionated) to use translations in commands
- Disconnected from the topic of how to run commands, can be used with anything that we decide on later
- Minimal implementation, no new deps 😸 

I moved all existing help files to the new setup, added Russian translations, and also added a few translated strings as an example of how it would look like

### Why toml?

I was thinking about different file formats that we could use, toml seems like a good match for us:

- We already use it in CLI
- Allows for multi-line strings
- Holds more structure than a .txt file
- Allows for interesting ways to specify pretty readable (opinionated) translation structures (see `cli/lib/localization.toml`)

/cc @toddself because I changed your *.txt based implementation for help and would love to hear what you think about this, @ceejbot as I mostly based it on your feedback and I'm super interested how it aligns with it
