### PR TITLE
fix(post-install): make top level post-install script compatible with POSIX shells like dash

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "lint-fix": "prettier --write '**/*.js'",
     "lint-md": "markdownlint \"**/*.md\" -i \"**/node_modules/**\"",
     "lint-registry": "cd services/registry; npm run lint",
-    "postinstall": "for d in cli services/{registry,workers,web,storage,common/boltzmann}; do cd $d; npm i; cd -; done",
+    "postinstall": "for d in cli $(printf 'services/%s ' 'registry' 'workers' 'web' 'storage' 'common/boltzmann'); do ( cd $d; npm i ); done",
     "start": "docker-compose up",
-    "test": "for d in cli services/{registry,workers,web,storage,common/boltzmann}; do cd $d; npm t; cd -; done"
+    "test": "for d in cli $(printf 'services/%s ' 'registry' 'workers' 'web' 'storage' 'common/boltzmann'); do ( cd $d; npm t ); done"
   }
 }


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

POSIX shells like `dash` don't support curly brace expansion (e.g. `"foo/{bar,baz}"` expanding to `"foo/bar foo/baz"`), and most linuxes symlink `/bin/sh` to `dash` or other limited shells rather `bash` or `zsh` for security reasons.

If you run `npm ci` from the top level directory this will cause the `post-install` script to infinitely loop with this error scattered in the stderr output: `sh: 1: cd: can't cd to services/{registry,workers,web,storage,common/boltzmann}`

This fix uses `printf` and subshells to mostly keep the conciseness and readability of the original while remaining compatible with most shells, and also uses a subshell to negate the requirement to `cd -` after each loop iteration.

# Checklist

* [ ] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
