### PR TITLE
cli/lib/main now rejects command names with file metachars

### DIFF
--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -3,6 +3,7 @@
 'use strict';
 
 module.exports = main;
+module.exports.unpack = unpack;
 
 const minimist = require('minimist');
 
@@ -10,44 +11,55 @@ const { load } = require('./config');
 const Api = require('./api');
 const log = require('./logger');
 
-async function main(argv) {
-  if (!argv[0]) {
-    argv[0] = 'help';
+async function unpack(argv, { log = log, load = load }) {
+  let [commandName = 'help'] = argv;
+  if (/[/\\]/.test(commandName)) {
+    log.log(`Ignoring malformed command name: ${JSON.stringify(commandName)}`);
+    commandName = 'help';
   }
 
+  let cmd;
   try {
-    let cmd;
-    try {
-      cmd = require(`./commands/${argv[0]}`);
-    } catch (e) {
-      cmd = require('./commands/help');
+    cmd = require(`./commands/${commandName}`);
+  } catch (e) {
+    cmd = require('./commands/help');
+  }
+
+  const { _, ...args } = minimist(argv.slice(1));
+  const config = await load();
+  const env = {};
+  for (const key in process.env) {
+    if (key.startsWith('ent_')) {
+      env[key.slice(4)] = process.env[key];
     }
+  }
 
-    const { _, ...args } = minimist(argv.slice(1));
-    const config = await load();
-    const env = {};
-    for (const key in process.env) {
-      if (key.startsWith('ent_')) {
-        env[key.slice(4)] = process.env[key];
-      }
-    }
+  const registry = args.registry || config.registry || env.registry || 'https://registry.entropic.dev';
 
-    const registry = args.registry || config.registry || env.registry || 'https://registry.entropic.dev';
+  const registryConfig = (config.registries || {})[registry] || {};
 
-    const registryConfig = (config.registries || {})[registry] || {};
+  // env is overridden by config, which is overridden by registry-specific
+  // config, ...
+  const bundle = {
+    ...env,
+    ...config,
+    ...registryConfig,
+    ...args,
+    argv: _,
+    api: new Api(registry),
+    log
+  };
 
-    // env is overridden by config, which is overridden by registry-specific
-    // config, ...
-    await cmd({
-      ...env,
-      ...config,
-      ...registryConfig,
-      ...args,
-      argv: _,
-      api: new Api(registry),
-      log
-    });
+  return {
+    cmd,
+    bundle,
+  };
+}
 
+async function main(argv) {
+  try {
+    const { cmd, bundle } = await unpack(argv, log);
+    await cmd(bundle);
     return 0;
   } catch (err) {
     console.log(err.stack);

--- a/cli/lib/main.js
+++ b/cli/lib/main.js
@@ -11,7 +11,7 @@ const { load } = require('./config');
 const Api = require('./api');
 const log = require('./logger');
 
-async function unpack(argv, { log = log, load = load }) {
+async function unpack(argv, { log = log, load = load } = {}) {
   let [commandName = 'help'] = argv;
   if (/[/\\]/.test(commandName)) {
     log.log(`Ignoring malformed command name: ${JSON.stringify(commandName)}`);
@@ -58,7 +58,7 @@ async function unpack(argv, { log = log, load = load }) {
 
 async function main(argv) {
   try {
-    const { cmd, bundle } = await unpack(argv, log);
+    const { cmd, bundle } = await unpack(argv);
     await cmd(bundle);
     return 0;
   } catch (err) {

--- a/cli/test/lib/main.js
+++ b/cli/test/lib/main.js
@@ -1,0 +1,68 @@
+const test = require('ava');
+const main = require('../../lib/main');
+const help = require('../../lib/commands/help');
+const whoami = require('../../lib/commands/whoami');
+const sinon = require('sinon');
+
+async function testUnpack(argv) {
+  const log = { log: sinon.spy(), error: sinon.spy() };
+  const load = sinon.spy(() => ({}));
+
+  const result = await main.unpack(argv, { log, load });
+  return { log, load, result };
+}
+
+test('empty argv dumps help', async t => {
+  const {
+    result: { cmd },
+    log: { log, error },
+    load,
+  } = await testUnpack([]);
+
+  t.is(cmd, help);
+  t.is(log.callCount, 0);
+  t.is(error.callCount, 0);
+  t.is(load.callCount, 1);
+});
+
+test('bad command name dumps help', async t => {
+  const badCommand = '../test/lib/main';  // Refers to this test module
+
+  const {
+    result: { cmd },
+    log: { log, error },
+    load,
+  } = await testUnpack([ badCommand ]);
+
+  t.is(cmd, help);
+  t.is(log.callCount, 1);
+  t.is(log.args[0][0], `Ignoring malformed command name: "${ badCommand }"`);
+  t.is(error.callCount, 0);
+  t.is(load.callCount, 1);
+});
+
+test('when you ask for help you get help', async t => {
+  const {
+    result: { cmd },
+    log: { log, error },
+    load,
+  } = await testUnpack([ 'help' ]);
+
+  t.is(cmd, help);
+  t.is(log.callCount, 0);
+  t.is(error.callCount, 0);
+  t.is(load.callCount, 1);
+});
+
+test('when you ask whoami you get whoami', async t => {
+  const {
+    result: { cmd },
+    log: { log, error },
+    load,
+  } = await testUnpack([ 'whoami' ]);
+
+  t.is(cmd, whoami);
+  t.is(log.callCount, 0);
+  t.is(error.callCount, 0);
+  t.is(load.callCount, 1);
+});


### PR DESCRIPTION
Fixes #251

This adds a check to function main so that when the first argument,
which is interpreted as a command name, has a file separator, it is
rejected, logged, and the command `help` is used instead.

To ease testing, this splits the analysis code out of `function main`
into `function unpack` which find the `cmd` to invoke but leaves the
invoking and error recovery to `main`.

This adds tests that a dodgy command is rejected, but that others like
`whoami` continue to function.

```sh
$ (pushd cli; npm t; popd)
$ npm run lint
```

# Change Type

* [ ] Feature
* [ ] Chore
* [X] Bug Fix

# Change Level

* [ ] major
* [X] minor
* [ ] patch

# Further Information (screenshots, bug report links, etc.)

# Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
