### PR TITLE
docs: Add WSL links to Hacking docs

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -21,3 +21,8 @@ Then go to <http://localhost:3000>.
 
 To run linting and formatting pre-commit, add a file in the project root called
 `.opt-in` with the content `pre-commit`.
+
+## Windows
+
+If you're on Windows, your best bet is to use
+[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

Closes #262 (for now)

Related: [this comment](https://github.com/entropic-dev/entropic/pull/247#discussion_r293035096)

Right now I think our Windows story is kind of "it might work, no idea," so I figure directing folks to WSL might be the best (short term) solution.

# Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
