### PR TITLE
Add snap pkg builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ allowed-list
 services/data/entropic-cache
 .opt-in
 .opt-out
+*.snap

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -1,0 +1,27 @@
+---
+name: ds
+summary: "ds: entropy delta; the entropic client"
+description: |
+  A client for the federated entropy package registry,
+base: core18
+grade: devel
+adopt-info: ds
+
+parts:
+  ds:
+    override-pull: |
+      snapcraftctl pull
+      DS_SNAP_VERSION=${DS_SNAP_VERSION:-master}
+      snapcraftctl set-version "${DS_SNAP_VERSION}"
+    source: .
+    plugin: nodejs
+    nodejs-version: 12.4.0
+    nodejs-package-manager: npm
+
+apps:
+  ds:
+    command: ds
+    plugs:
+      - home
+      - network-bind
+      - network

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -1,5 +1,5 @@
 ---
-name: ds
+name: entropic-ds
 summary: "ds: entropy delta; the entropic client"
 description: |
   A client for the federated entropy package registry,

--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -21,7 +21,7 @@ If you're using Arch Linux, install the [`nodejs-entropic`](https://aur.archlinu
 
 ### Snap packages (multiple Linux distributions)
 
-If you're using a Linxu distro that support `snapd`, you can install using `snap`:
+If you're using a Linxu distro that supports `snapd`, you can install using `snap`:
 
 ```sh
 # You might need to `sudo snap` if you aren't logged in with `snap login`

--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -18,3 +18,12 @@ brew install https://raw.githubusercontent.com/entropic-dev/entropic/master/docs
 ### Arch Linux
 
 If you're using Arch Linux, install the [`nodejs-entropic`](https://aur.archlinux.org/packages/nodejs-entropic/) package from the AUR.
+
+### Snap packages (multiple Linux distributions)
+
+If you're using a Linxu distro that support `snapd`, you can install using `snap`:
+
+```sh
+# You might need to `sudo snap` if you aren't logged in with `snap login`
+snap install entropic-ds
+```


### PR DESCRIPTION
# Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

This adds a build file (`snapcraft.yaml`) for building a [snap package](https://snapcraft.io/), which can be pushed up to the snap store (I have published an initial _edge channel_ release [here](https://snapcraft.io/entropic-ds) and would be happy to hand over ownership to current maintainers) and installed on any Linux that supports `snapd`.

~Following up, and given credentials for talking to the snap store, `.travis.yml` could be updated to continuously push `master` builds to the aforementioned edge channel.~
Actually you can add a GitHub integration (webhook) easily from snapcraft.io to do the continuous builds on Canonical's build farm and published continuously to the store. 🎉

# Checklist

* [ ] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
