### PR TITLE
Wait for DBs to start

### DIFF
--- a/services/common/boltzmann/middleware/redis.js
+++ b/services/common/boltzmann/middleware/redis.js
@@ -26,7 +26,16 @@ function createRedisMW({
   redisURL = process.env.REDIS_URL || 'redis://localhost:6379'
 } = {}) {
   return next => {
-    const client = redis.createClient(redisURL);
+    const client = redis.createClient(redisURL, {
+      retry_strategy: function (options) {
+        if (options.attempt > 10) {
+          // Fail with redis error
+          return undefined;
+        }
+        // reconnect after
+        return Math.min(options.attempt * 50, 250);
+      },
+    });
 
     return context => {
       context.redis = client;

--- a/services/storage/.env-example
+++ b/services/storage/.env-example
@@ -1,6 +1,6 @@
 NODE_ENV=dev
 DEV_LATENCY_ERROR_MS=10000
-POSTGRES_URL=postgres://postgres@db:5432/entropic_dev
+POSTGRES_URL=postgres://postgres@db:5432/entropic_dev?connectionTimeoutMillis=5000
 PGHOST=db
 REDIS_URL=redis://redis:6379
 PORT=3002


### PR DESCRIPTION
# Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

When setting up locally via `docker-compose up` I had to try and try again otherwise containers that depended on redis and pg would fail to connect.  First I added some minor sleeps to the container commands and then later I came back and added a `retry_strategy` for redis and a query param to pg to extend the connection timeout.  The former is a code change and the latter was added to the relevant `.env-example`.

I am not adverse to adding tests or moving the redis stuff more into a config but these otherwise sensible values have been working well for me.

# Checklist

* [ ] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
