### PR TITLE
Remove duplicate reference to Contributing doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Publish a new package-version with `ds publish`.
 
 ## Contributing
 
-Entropic is, at the moment of this writing, the work of two people: [Chris Dickinson](https://github.com/chrisdickinson) and [C J Silverio](https://github.com/ceejbot). They are not sponsored by anybody nor do they represent anyone but themselves. Chris and Ceej are seeking additional contributors but wish to onboard newcomers slowly. The project is new enough that clear direction does not always exist in the code, so contributors will need to work closely with us. Read [CONTRIBUTING guide](./CONTRIBUTING.md)
+Entropic is, at the moment of this writing, the work of two people: [Chris Dickinson](https://github.com/chrisdickinson) and [C J Silverio](https://github.com/ceejbot). They are not sponsored by anybody nor do they represent anyone but themselves. Chris and Ceej are seeking additional contributors but wish to onboard newcomers slowly. The project is new enough that clear direction does not always exist in the code, so contributors will need to work closely with us.
 
 For more, see [Contributing](./.github/CONTRIBUTING.md) and our [Code of Conduct](./.github/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)
The first link to the Contributing doc in the readme no longer links to `Contributing.md` successfully. However https://github.com/entropic-dev/entropic/pull/131 added a separate paragraph to the readme with a working link to `Contributing.md`, so this PR removes the link that no longer works.

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
