### PR TITLE
fix(vcpm-sync): Use process.exitCode instead of process.exit()

### DIFF
--- a/tools/vcpm-sync/main.js
+++ b/tools/vcpm-sync/main.js
@@ -205,11 +205,11 @@ if (require.main === module) {
   main(minimist(process.argv.slice(2)))
     .then(code => {
       if (Number(code)) {
-        process.exit(code);
+        process.exitCode = code;
       }
     })
     .catch(err => {
       console.error(err.stack);
-      process.exit(1);
+      process.exitCode = 1;
     });
 }


### PR DESCRIPTION
On certain platforms (e.g. Windows) the console streams are async,
since `process.exit()` immediately exists the process the console
streams may not have been flushed when the process ends.

Migrating to `process.exitCode` assignment, will allow the process to
end "naturally" when all async work is completed but still use the
specified exit code.

---

# Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

# Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
