### PR TITLE
doc: add LORE.md doc

### DIFF
--- a/docs/LORE.md
+++ b/docs/LORE.md
@@ -1,0 +1,85 @@
+# LORE
+
+The intention of this document is to catalog a list of links to important or
+notable writings about the folklore of this project. The goal is to point at
+the things that shape the project without recapitulating them in full here,
+providing them as a resource for newcomers to the project.
+
+## Posts / Definitions
+
+### A community ownership pact
+
+![Ceej and Chris agree that neither of them are in this for a retirement.](/docs/assets/community-ownership-pact.png)
+
+### [The economics of package management](https://github.com/ceejbot/economics-of-package-management)
+
+The text and materials of the talk that introduced this project.
+
+### [The economics of open source](https://www.youtube.com/watch?v=MO8hZlgK5zc&feature=youtu.be)
+
+The video form of the above.
+
+### [Conway's Law](https://en.wikipedia.org/wiki/Conway%27s_law)
+
+What _is_ Conway's law, anyway?
+
+### [Gall's Law](https://en.wikipedia.org/wiki/John_Gall_\(author\)#Gall's_law)
+
+Also, Gall's law?
+
+### [The Tyranny of Structurelessness](https://www.jofreeman.com/joreen/tyranny.htm)
+
+Structurelessness can work to hide power structures. Very applicable to open
+source project development.
+
+### [Write code that is easy to delete](https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to)
+
+A great post about how to think about the cost of abstraction.
+
+### [How ENTROPIC picks packages](https://discourse.entropic.dev/t/issues-with-prs/55/2?u=chrisdickinson)
+
+See the "Tooling" section of this post.
+
+### [HTTP API Design language](https://gist.github.com/chrisdickinson/e94ae588ba06bbcaaf21297345f22008)
+
+Chris shares his HTTP api design foibles.
+
+### [What's a clacks overhead header?](https://xclacksoverhead.org/home/about)
+
+Why do we send clacks overhead headers? What purpose could they serve? Who is
+Terry?
+
+### [VFP? GCU? (D)ROU?](https://en.wikipedia.org/wiki/List_of_spacecraft_in_the_Culture_series)
+
+You might spot one of these acronyms when `curl`'ing the `/` path of an
+ENTROPIC registry and wonder at their significance. Well, wonder no more!
+
+## Quotes / Tweets / Tweetstorms
+
+### ["Code is never the challenge."](https://mobile.twitter.com/ceejbot/status/761569569802551300)
+
+- ceejbot
+
+### ["Process is a system, and as a system it is subject to Gall's Law"](https://mobile.twitter.com/isntitvacant/status/1138996005976756227)
+
+- chrisdickinson
+
+### ["The cost of copied code is so much lower than the cost of the wrong abstraction."](https://mobile.twitter.com/jefflembeck/status/1141048466723835904)
+
+- aredridel
+
+### ["We keep the registry up."](https://mobile.twitter.com/jefflembeck/status/1136640077562408965)
+
+- jefflembeck
+
+### ["Software is fun. Easter eggs are a tradition."](https://mobile.twitter.com/ceejbot/status/1135441511624192000)
+
+- ceejbot
+
+### ["Chris says the raccoon is named 'Static.'"](https://mobile.twitter.com/ceejbot/status/1135119921564737541)
+
+- ceejbot (but also chrisdickinson I guess?)
+
+### ["Conway's law is a continuous force"](https://mobile.twitter.com/isntitvacant/status/1123654381679759360)
+
+- chrisdickinson


### PR DESCRIPTION
This adds a new document, `docs/LORE.md`, containing links to posts, writing, & tweets that inform the project's philosophy. (Thanks for the document naming suggestion, @iarna!) The goal is to keep a running document of important links instead of committing to writing up (& maintaining) a larger "project philosophy" post – this makes it easier to keep up to date, and thus more valuable for folks new to the project.

Had to resist attaching a gif of Brent Spiner. It was difficult, let me tell you.

What else should we add?