### PR TITLE
docs: add link to hacking docs in main readme

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,7 +83,7 @@ So you wanna contribute some code! That's great! This project uses GitHub Pull R
 
 If this seems like a lot or you aren't able to do all this setup, you might also be able to [edit the files directly](https://help.github.com/articles/editing-files-in-another-user-s-repository/) without having to do any of this setup. Yes, [even code](#contribute-code).
 
-If you want to go the usual route and run the project locally, though, please read the [the setup documentation](./README.md) for the various parts of Entropic.
+If you want to go the usual route and run the project locally, though, please read the [the setup documentation](/docs/HACKING.md) for the various parts of Entropic.
 
 ## Contribute Documentation
 
@@ -237,7 +237,7 @@ All of the below positions are granted based on the project team's needs, as wel
 
 You can spot a collaborator on the repo by looking for the `[Collaborator]` or `[Owner]` tags next to their names.
 
-See the [entropic process document](../docs/rfcs/0001-entropic-workflow.md) for a description of how we'd like to discuss problems and solutions in this project.
+See the [entropic process document](/docs/entropic-workflow.md) for a description of how we'd like to discuss problems and solutions in this project.
 
 Permission | Description
 --- | ---

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Entropic is, at the moment of this writing, the work of two people: [Chris Dicki
 
 For more, see [Contributing](./.github/CONTRIBUTING.md) and our [Code of Conduct](./.github/CODE_OF_CONDUCT.md).
 
+If you just want to get things up and running, first check out [the docs](./docs/HACKING.md).
+
 ## Moderators
 
 - **[ceejbot](https://github.com/ceejbot)**


### PR DESCRIPTION
## Change Type (Feature, Chore, Bug Fix, One Pager, etc.)

Chore.

## Description

<!--
Is this a breaking change?

Does this close an issue or another PR? If so, please add
Fixes #[Issue Number] or Closes #[Issue Number]
(example: Closes #123)

Is there an external bug report or discussion (for example,
on social media or in Discource)?

Is there a related screenshot?
-->

Fixes #295
Also fixes a few links in the Contributing guide.

## How to test

## Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)
