### PR TITLE
fix(namespaces): change sort method in namespace model by order

### DIFF
--- a/services/storage/handlers/namespaces.js
+++ b/services/storage/handlers/namespaces.js
@@ -17,10 +17,7 @@ const exists = packageExists({
 });
 module.exports = [
   fork.get('/v1/namespaces', namespaces),
-  fork.get(
-    '/v1/namespaces/namespace/:namespace([^@]+)@:host/members',
-    authn.optional(members)
-  ),
+  fork.get('/v1/namespaces/namespace/:namespace([^@]+)@:host/members', authn.optional(members)),
   fork.post(
     '/v1/namespaces/namespace/:namespace([^@]+)@:host/members/:invitee',
     authn.required(findInvitee(canChangeNamespace(invite)))
@@ -113,7 +110,7 @@ async function namespaces(context, params) {
       'host.active': true,
       'host.name': process.env.EXTERNAL_HOST.replace(/^http(s)?:\/\//, '')
     })
-    .sort('name')
+    .order('name')
     .then();
   const objects = namespaces.map(ns => ns.name);
   return response.json({ objects });
@@ -170,9 +167,7 @@ async function invite(context, { invitee, namespace, host }) {
     active: true
   });
 
-  context.logger.info(
-    `${invitee} invited to join ${namespace}@${host} by ${context.user.name}`
-  );
+  context.logger.info(`${invitee} invited to join ${namespace}@${host} by ${context.user.name}`);
   return response.message(`${invitee} invited to join ${namespace}@${host}.`);
 }
 
@@ -195,13 +190,9 @@ async function remove(context, { invitee, namespace, host }) {
     .then();
 
   if (membership.length === 0) {
-    return response.message(
-      `${invitee} was not a member of ${namespace}@${host}.`
-    );
+    return response.message(`${invitee} was not a member of ${namespace}@${host}.`);
   }
-  context.logger.info(
-    `${invitee} removed from ${namespace}@${host} by ${context.user.name}`
-  );
+  context.logger.info(`${invitee} removed from ${namespace}@${host} by ${context.user.name}`);
 
   return response.message(`${invitee} removed from ${namespace}@${host}.`);
 }
@@ -267,13 +258,9 @@ async function accept(context, { namespace, host, name, member }) {
     });
 
   context.logger.info(
-    `${
-      context.user.name
-    } accepted the invitation for ${member} to join ${namespace}@${host}/${name}`
+    `${context.user.name} accepted the invitation for ${member} to join ${namespace}@${host}/${name}`
   );
-  return response.message(
-    `${member} is now a maintainer for ${namespace}@${host}/${name}`
-  );
+  return response.message(`${member} is now a maintainer for ${namespace}@${host}/${name}`);
 }
 
 async function decline(context, { namespace, host, name, member }) {
@@ -299,11 +286,7 @@ async function decline(context, { namespace, host, name, member }) {
     });
 
   context.logger.info(
-    `${
-      context.user.name
-    } declined the invitation for ${member} to join ${namespace}@${host}/${name}`
+    `${context.user.name} declined the invitation for ${member} to join ${namespace}@${host}/${name}`
   );
-  return response.message(
-    `You have declined the invitation for ${member} to join ${namespace}@${host}/${name}`
-  );
+  return response.message(`You have declined the invitation for ${member} to join ${namespace}@${host}/${name}`);
 }


### PR DESCRIPTION
## Change Type (Feature, Chore, Bug Fix, One Pager, etc.)

Fix

## Description

<!--
Is this a breaking change?

Does this close an issue or another PR? If so, please add
Fixes #[Issue Number] or Closes #[Issue Number]
(example: Closes #123)

Is there an external bug report or discussion (for example,
on social media or in Discource)?

Is there a related screenshot?
-->

When requesting list of namespaces, an error is thrown:

<img width="818" alt="Screen Shot 2019-06-23 at 6 27 17 PM" src="https://user-images.githubusercontent.com/9284690/59983391-90724200-95e4-11e9-89db-327d4f2509a5.png">

This is because the model is sorting the returning list by name but using an incorrect method from the ORM (`sort`). This PR changes the method to `order()` and the endpoint gets fixed.

## How to test

Request the `/v1/namespaces` without this change (it will return an error) and then with this change you will get the list of namespaces sorted by name.

## Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
