### PR TITLE
fix: package serialization changes

### DIFF
--- a/services/storage/models/package-version.js
+++ b/services/storage/models/package-version.js
@@ -51,6 +51,7 @@ module.exports = class PackageVersion {
     const {
       created,
       modified,
+      signatures,
       derivedFiles,
       ...content
     } = await this.serialize();

--- a/services/storage/models/package.js
+++ b/services/storage/models/package.js
@@ -57,6 +57,10 @@ module.exports = class Package {
 
     const acc = {};
     for (const version of versions) {
+      if (version.yanked) {
+        continue;
+      }
+
       const [integrity, _] = await version.toSSRI();
       acc[version.version] = String(integrity);
     }


### PR DESCRIPTION
Two changes contained:

1. Signatures should not be part of the package version content, because that's the data that's getting signed. Pluck them out!
2. Omit yanked versions from the top-level manifest. Once yanked, the package-version continues to be available at the content address and through the `/v1/packages/package/<pkg>/versions` endpoint. (Alternatively: we could add it to the versions map with `{yanked: <object id>}`.)