### PR TITLE
Add stub tests for refactored services

### DIFF
--- a/services/common/boltzmann/package.json
+++ b/services/common/boltzmann/package.json
@@ -20,6 +20,7 @@
     "eslint": "~5.16.0",
     "eslint-config-prettier": "~4.3.0",
     "eslint-plugin-prettier": "~3.1.0",
+    "mocha": "~6.1.4",
     "prettier": "~1.17.1"
   },
   "homepage": "https://github.com/entopic-dev/entropic#readme",
@@ -37,6 +38,6 @@
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "prettier --write '**/*.js'",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha -R spec"
   }
 }

--- a/services/common/boltzmann/test/00-basics.spec.js
+++ b/services/common/boltzmann/test/00-basics.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env node, mocha */
+'use strict';
+
+describe('entropic-common-boltzman', () => {
+  it(
+    'has tests',
+    () => { true }
+  );
+});

--- a/services/registry/test/00-basics.spec.js
+++ b/services/registry/test/00-basics.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env node, mocha */
+'use strict';
+
+describe('entropic-registry', () => {
+  it(
+    'has tests',
+    () => { true }
+  );
+});

--- a/services/web/test/00-basics.spec.js
+++ b/services/web/test/00-basics.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env node, mocha */
+'use strict';
+
+describe('entropic-web', () => {
+  it(
+    'has tests',
+    () => { true }
+  );
+});

--- a/services/workers/package.json
+++ b/services/workers/package.json
@@ -7,9 +7,12 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha -R spec"
   },
   "dependencies": {
     "beanstalkd": "~2.2.1"
+  },
+  "devDependencies": {
+    "mocha": "~6.1.4"
   }
 }

--- a/services/workers/test/00-basics.spec.js
+++ b/services/workers/test/00-basics.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env node, mocha */
+'use strict';
+
+describe('entropic-registry', () => {
+  it(
+    'has tests',
+    () => { true }
+  );
+});


### PR DESCRIPTION
Adds stub tests for boltzmann, registry, web, workers
Adds devDependency on mocha where absent

## Change Type (Feature, Chore, Bug Fix, One Pager, etc.)
Bug Fix

## Description
Make tests run for most subservices.
Storage tests look like they need to be run in a container, so I didn't touch them.


## How to test
```
npm t
```
in root directory will now only fail for the services/storage subdir

## Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current Node)

Tested with node v12.4.0