### PR TITLE
nitpick(web): avoid ternary for plurals [WIP - do not merge yet] 

### DIFF
--- a/services/web/handlers/auth.js
+++ b/services/web/handlers/auth.js
@@ -384,9 +384,9 @@ async function handleTokenAction(context) {
 
     context.session.set(
       'banner',
-      `Successfully deleted ${count} token${count === 1 ? '' : 's'}.`
+      `Successfully deleted tokens: ${count}.`
     );
-    context.logger.info(`${user.name} deleted a token`);
+    context.logger.info(`${user.name} deleted tokens: ${count}`);
     return response.redirect('/tokens');
   }
 }


### PR DESCRIPTION
## Change Type (Feature, Chore, Bug Fix, One Pager, etc.)
Nitpick

## Description
It's much easier to internationalize when code is not mixed with formatting.  `count == 1 ? "" : "s"` in particular is hard to deal with: some languages have singular, dual, plural ; some languages have a special plural for numbers >= 5, etc.

## How to test
Not yet tested.

## Checklist

* [x] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
