### PR TITLE
fix(install): change hash for type on install script

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -3,10 +3,12 @@ set -e
 
 cd /tmp
 
-if hash curl 2>/dev/null; then
-  curl -SsL https://www.entropic.dev/ds-latest.tgz -o ds-latest.tgz
-elif hash wget 2>/dev/null; then
-  wget https://www.entropic.dev/ds-latest.tgz -o ds-latest.tgz
+ENTROPIC_SRC="https://www.entropic.dev/ds-latest.tgz"
+
+if type wget &>/dev/null; then
+  curl -SsL $ENTROPIC_SRC -o ds-latest.tgz
+elif type wget &>/dev/null; then
+  curl $ENTROPIC_SRC -o ds-latest.tgz
 else
   echo 'Please install curl or wget!'
   exit 1

--- a/misc/install.sh
+++ b/misc/install.sh
@@ -5,10 +5,10 @@ cd /tmp
 
 ENTROPIC_SRC="https://www.entropic.dev/ds-latest.tgz"
 
-if type wget &>/dev/null; then
+if hash curl 2>/dev/null; then
   curl -SsL $ENTROPIC_SRC -o ds-latest.tgz
-elif type wget &>/dev/null; then
-  curl $ENTROPIC_SRC -o ds-latest.tgz
+elif hash wget 2>/dev/null; then
+  wget $ENTROPIC_SRC -o ds-latest.tgz
 else
   echo 'Please install curl or wget!'
   exit 1


### PR DESCRIPTION
## Change Type (Feature, Chore, Bug Fix, One Pager, etc.)

Fix

## Description

I changed `hash` for `type` because it was actually not falling to `elif` and `else` code blocks, just emit exception `hash: no such command: ...` and just put the `ds` on a variable because it was actually the same

Also I redirect `stderr` and `stdout` to `/dev/null` because `type` prints `command is /route` in `stdout`

<!--
Is this a breaking change?

Does this close an issue or another PR? If so, please add
Fixes #[Issue Number] or Closes #[Issue Number]
(example: Closes #123)

Is there an external bug report or discussion (for example,
on social media or in Discource)?

Is there a related screenshot?
-->

## How to test
 Run `./misc/install.sh` on root folder
## Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested in supported environments (common browsers or current Node)
